### PR TITLE
Prepare track to generate README's with configlet CLI

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,0 +1,19 @@
+## Running tests
+
+Gleam projects are tested using `rebar3`, the standard Erlang build tool. 
+Please refer to [the installation
+instructions](http://exercism.io/languages/gleam/installation) for more information.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+## Questions?
+
+For detailed information about the Gleam track, please refer to the
+[help page](http://exercism.io/languages/gleam) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -10,7 +10,7 @@ The objectives are simple:
 
 - Write a function that returns the string "Hello, World!".
 - Run the test suite and make sure that it succeeds.
-- Submit your solution and check it on the website.
+- Submit your solution and check it at the website.
 
 If everything goes well, you will be ready to fetch your first real exercise.
 


### PR DESCRIPTION
I learned that there is a CLI command to generate the README's, so I copied the track info to `exercise-readme-insert.md` and then generated hello-world README with configlet.