### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "5b8edcb6-f029-42dc-85e7-488c07978354",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Gleam locally",
+      "blurb": "Learn how to install Gleam locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "f7027931-1ccb-4645-b3d9-8791bb0945dd",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Gleam",
+      "blurb": "An overview of how to get started from scratch with Gleam"
+    },
+    {
+      "uuid": "7a8a5513-0a16-4f07-b996-3328455582f7",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Gleam track",
+      "blurb": "Learn how to test your Gleam exercises on Exercism"
+    },
+    {
+      "uuid": "eb83c4b2-b7cc-42b7-9221-7a243ffae804",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Gleam resources",
+      "blurb": "A collection of useful resources to help you master Gleam"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
