### PR TITLE
Make examples compile with gleam 0.15.1 and recent stdlib

### DIFF
--- a/exercises/practice/forth/rebar.config
+++ b/exercises/practice/forth/rebar.config
@@ -8,6 +8,6 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.12.0"},
+    {gleam_stdlib, "0.15.0"},
     {gleam_otp, "0.1.0"}
 ]}.

--- a/exercises/practice/hello-world/rebar.config
+++ b/exercises/practice/hello-world/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.12.0"}
+    {gleam_stdlib, "0.15.0"}
 ]}.

--- a/exercises/practice/leap/rebar.config
+++ b/exercises/practice/leap/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.12.0"}
+    {gleam_stdlib, "0.15.0"}
 ]}.

--- a/exercises/practice/leap/test/leap_test.gleam
+++ b/exercises/practice/leap/test/leap_test.gleam
@@ -1,5 +1,5 @@
 import leap
-import gleam/expect
+import gleam/should
 
 pub fn year_2015_test() {
   leap.is_leap_year(2015)

--- a/exercises/practice/resistor-color/rebar.config
+++ b/exercises/practice/resistor-color/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.12.0"}
+    {gleam_stdlib, "0.15.0"}
 ]}.

--- a/exercises/practice/resistor-color/test/resistor_color_test.gleam
+++ b/exercises/practice/resistor-color/test/resistor_color_test.gleam
@@ -1,55 +1,55 @@
-import resistor.{
+import resistor_color.{
   Black, Blue, Brown, Green, Grey, Orange, Red, Violet, White, Yellow,
 }
-import gleam/expect
+import gleam/should
 
 pub fn black_test() {
-  resistor.code(Black)
+  resistor_color.code(Black)
   |> should.equal(0)
 }
 
 pub fn brown_test() {
-  resistor.code(Brown)
+  resistor_color.code(Brown)
   |> should.equal(1)
 }
 
 pub fn red_test() {
-  resistor.code(Red)
+  resistor_color.code(Red)
   |> should.equal(2)
 }
 
 pub fn orange_test() {
-  resistor.code(Orange)
+  resistor_color.code(Orange)
   |> should.equal(3)
 }
 
 pub fn yellow_test() {
-  resistor.code(Yellow)
+  resistor_color.code(Yellow)
   |> should.equal(4)
 }
 
 pub fn green_test() {
-  resistor.code(Green)
+  resistor_color.code(Green)
   |> should.equal(5)
 }
 
 pub fn blue_test() {
-  resistor.code(Blue)
+  resistor_color.code(Blue)
   |> should.equal(6)
 }
 
 pub fn violet_test() {
-  resistor.code(Violet)
+  resistor_color.code(Violet)
   |> should.equal(7)
 }
 
 pub fn grey_test() {
-  resistor.code(Grey)
+  resistor_color.code(Grey)
   |> should.equal(8)
 }
 
 pub fn white_test() {
-  resistor.code(White)
+  resistor_color.code(White)
   |> should.equal(9)
 }
 
@@ -67,6 +67,6 @@ pub fn colors_test() {
     White,
   ]
 
-  resistor.colors()
+  resistor_color.colors()
   |> should.equal(colors)
 }

--- a/exercises/practice/two-fer/rebar.config
+++ b/exercises/practice/two-fer/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.12.0"}
+    {gleam_stdlib, "0.15.0"}
 ]}.

--- a/exercises/practice/two-fer/src/two_fer.gleam
+++ b/exercises/practice/two-fer/src/two_fer.gleam
@@ -1,4 +1,4 @@
-import gleam/result.{Option}
+import gleam/option.{Option}
 
 pub fn two_fer(name: Option(String)) -> String {
   "todo"

--- a/exercises/practice/two-fer/test/two_fer_test.gleam
+++ b/exercises/practice/two-fer/test/two_fer_test.gleam
@@ -1,13 +1,13 @@
 import two_fer.{two_fer}
-import gleam/result
-import gleam/expect
+import gleam/option.{None, Some}
+import gleam/should
 
 pub fn no_name_test() {
-  two_fer(result.none())
+  two_fer(None)
   |> should.equal("One for you, one for me")
 }
 
 pub fn with_name_test() {
-  two_fer(Ok("Gilberto Barros"))
+  two_fer(Some("Gilberto Barros"))
   |> should.equal("One for Gilberto Barros, one for me")
 }


### PR DESCRIPTION
When there is a new release of gleam_otp, this should also work with 0.16 I think