### PR TITLE
Update deps and fix two-fer example

### DIFF
--- a/exercises/practice/forth/rebar.config
+++ b/exercises/practice/forth/rebar.config
@@ -8,6 +8,6 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.15.0"},
-    {gleam_otp, "0.1.0"}
+    {gleam_stdlib, "~> 0.16.0"},
+    {gleam_otp, "~> 0.1.5"}
 ]}.

--- a/exercises/practice/hello-world/rebar.config
+++ b/exercises/practice/hello-world/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.15.0"}
+    {gleam_stdlib, "~> 0.16.0"}
 ]}.

--- a/exercises/practice/leap/rebar.config
+++ b/exercises/practice/leap/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.15.0"}
+    {gleam_stdlib, "~> 0.16.0"}
 ]}.

--- a/exercises/practice/resistor-color/gleam.toml
+++ b/exercises/practice/resistor-color/gleam.toml
@@ -1,1 +1,1 @@
-name = "resistor"
+name = "resistor_color"

--- a/exercises/practice/resistor-color/rebar.config
+++ b/exercises/practice/resistor-color/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.15.0"}
+    {gleam_stdlib, "~> 0.16.0"}
 ]}.

--- a/exercises/practice/two-fer/example/two_fer.gleam
+++ b/exercises/practice/two-fer/example/two_fer.gleam
@@ -1,8 +1,8 @@
-import gleam/result.{Option}
+import gleam/option.{Option}
 import gleam/string
 
 pub fn two_fer(name: Option(String)) -> String {
   "One for "
-  |> string.append(result.unwrap(name, "you"))
+  |> string.append(option.unwrap(name, "you"))
   |> string.append(", one for me")
 }

--- a/exercises/practice/two-fer/rebar.config
+++ b/exercises/practice/two-fer/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.15.0"}
+    {gleam_stdlib, "~> 0.16.0"}
 ]}.


### PR DESCRIPTION
Hi!

I updated gleam_otp in the forth exercise to 0.1.5 for compatibility with gleam 0.16. I also changed the stdlib dependency to 0.16 everywhere and loosened the dependency specs with `~>` to let rebar get point releases with fixes when available.

I checked all example implementations and fixed one of them to compile with newer gleam.