### PR TITLE
Remove syntax highlighting hack

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-*.gleam linguist-language=Rust
 examples/* linguist-documentation=false


### PR DESCRIPTION
This config tricked github into showing Gleam as Rust to get highlighting. Unfortunately it didn't work very well so I've removed it.