### PR TITLE
Fix configlet status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Exercism Gleam Track
 
-![Configlet Status](https://github.com/exercism/gleam/workflows/configlet/badge.svg)
+[![Configlet Status](https://github.com/exercism/gleam/actions/workflows/configlet.yml/badge.svg)](https://github.com/exercism/gleam/actions/workflows/configlet.yml)
 
 Exercism exercises in Gleam.


### PR DESCRIPTION
The configlet workflow name has changed, thus has its reference URL.  Added linkback to the workflow so you can see what went wrong when it has failed.