### PR TITLE
Fix glob

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,4 @@ jobs:
         run: bin/test
 
       - name: Check formatting
-        run: gleam format --check exercises/*/*/{src,test,.meta}/**/*.gleam
+        run: gleam format --check exercises/*/*/{src,test,.meta}/*.gleam


### PR DESCRIPTION
I'm a fool and merged too early. I don't know why globbing like this does not work here, I guess GitHub actions uses a different shell syntax to my machine.