### PR TITLE
Sync all metadata, docs and tests

### DIFF
--- a/exercises/practice/accumulate/.docs/instructions.md
+++ b/exercises/practice/accumulate/.docs/instructions.md
@@ -1,9 +1,6 @@
 # Instructions
 
-Implement the `accumulate` operation, which, given a collection and an
-operation to perform on each element of the collection, returns a new
-collection containing the result of applying that operation to each element of
-the input collection.
+Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.
 
 Given the collection of numbers:
 
@@ -21,6 +18,5 @@ Check out the test suite to see the expected function signature.
 
 ## Restrictions
 
-Keep your hands off that collect/map/fmap/whatchamacallit functionality
-provided by your standard library!
+Keep your hands off that collect/map/fmap/whatchamacallit functionality provided by your standard library!
 Solve this one yourself using other basic tools instead.

--- a/exercises/practice/accumulate/.meta/tests.toml
+++ b/exercises/practice/accumulate/.meta/tests.toml
@@ -1,0 +1,30 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[64d97c14-36dd-44a8-9621-2cecebd6ed23]
+description = "accumulate empty"
+
+[00008ed2-4651-4929-8c08-8b4dbd70872e]
+description = "accumulate squares"
+
+[551016da-4396-4cae-b0ec-4c3a1a264125]
+description = "accumulate upcases"
+
+[cdf95597-b6ec-4eac-a838-3480d13d0d05]
+description = "accumulate reversed strings"
+
+[bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb]
+description = "accumulate recursively"
+include = false
+
+[0b357334-4cad-49e1-a741-425202edfc7c]
+description = "accumulate recursively"
+reimplements = "bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb"

--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -1,7 +1,13 @@
 # Instructions
 
-An anagram is a rearrangement of letters to form a new word.
-Given a word and a list of candidates, select the sublist of anagrams of the given word.
+An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
+A word is not its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
 
-Given `"listen"` and a list of candidates like `"enlists" "google" "inlets" "banana"` the program should return a list containing
-`"inlets"`.
+Given a target word and a set of candidate words, this exercise requests the anagram set: the subset of the candidates that are anagrams of the target.
+
+The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
+Words in the anagram set should have the same letter case as in the candidate set.
+
+Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -20,5 +20,7 @@
       "manifest.toml"
     ]
   },
-  "blurb": "Given a word and a list of possible anagrams, select the correct sublist."
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
+  "source": "Inspired by the Extreme Startup game",
+  "source_url": "https://github.com/rchatley/extreme_startup"
 }

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,0 +1,86 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+include = false
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+include = false
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
+
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+include = false
+
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+include = false
+
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+include = false
+
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+include = false
+
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+include = false
+
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+include = false
+
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+include = false
+
+[68934ed0-010b-4ef9-857a-20c9012d1ebf]
+description = "words are not anagrams of themselves"
+include = false
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
+description = "words are not anagrams of themselves even if letter case is partially different"
+include = false
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
+description = "words are not anagrams of themselves even if letter case is completely different"
+include = false
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"
+include = false
+
+[33d3f67e-fbb9-49d3-a90e-0beb00861da7]
+description = "words other than themselves can be anagrams"
+include = false
+reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"

--- a/exercises/practice/bob/.docs/instructions.md
+++ b/exercises/practice/bob/.docs/instructions.md
@@ -1,6 +1,7 @@
-# Description
+# Instructions
 
-Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+Bob is a lackadaisical teenager.
+In conversation, his responses are very limited.
 
 Bob answers 'Sure.' if you ask him a question, such as "How are you?".
 
@@ -8,8 +9,7 @@ He answers 'Whoa, chill out!' if you YELL AT HIM (in all capitals).
 
 He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
 
-He says 'Fine. Be that way!' if you address him without actually saying
-anything.
+He says 'Fine. Be that way!' if you address him without actually saying anything.
 
 He answers 'Whatever.' to anything else.
 

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -22,5 +22,5 @@
   },
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,0 +1,85 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
+
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
+
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
+
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
+
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
+
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
+
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
+
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
+
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"

--- a/exercises/practice/bowling/.docs/instructions.md
+++ b/exercises/practice/bowling/.docs/instructions.md
@@ -2,35 +2,30 @@
 
 Score a bowling game.
 
-Bowling is a game where players roll a heavy ball to knock down pins
-arranged in a triangle. Write code to keep track of the score
-of a game of bowling.
+Bowling is a game where players roll a heavy ball to knock down pins arranged in a triangle.
+Write code to keep track of the score of a game of bowling.
 
 ## Scoring Bowling
 
-The game consists of 10 frames. A frame is composed of one or two ball
-throws with 10 pins standing at frame initialization. There are three
-cases for the tabulation of a frame.
+The game consists of 10 frames.
+A frame is composed of one or two ball throws with 10 pins standing at frame initialization.
+There are three cases for the tabulation of a frame.
 
-- An open frame is where a score of less than 10 is recorded for the
-  frame. In this case the score for the frame is the number of pins
-  knocked down.
+- An open frame is where a score of less than 10 is recorded for the frame.
+  In this case the score for the frame is the number of pins knocked down.
 
-- A spare is where all ten pins are knocked down by the second
-  throw. The total value of a spare is 10 plus the number of pins
-  knocked down in their next throw.
+- A spare is where all ten pins are knocked down by the second throw.
+  The total value of a spare is 10 plus the number of pins knocked down in their next throw.
 
-- A strike is where all ten pins are knocked down by the first
-  throw. The total value of a strike is 10 plus the number of pins
-  knocked down in the next two throws. If a strike is immediately
-  followed by a second strike, then the value of the first strike
-  cannot be determined until the ball is thrown one more time.
+- A strike is where all ten pins are knocked down by the first throw.
+  The total value of a strike is 10 plus the number of pins knocked down in the next two throws.
+  If a strike is immediately followed by a second strike, then the value of the first strike cannot be determined until the ball is thrown one more time.
 
 Here is a three frame example:
 
-|  Frame 1   |  Frame 2   |     Frame 3      |
-| :--------: | :--------: | :--------------: |
-| X (strike) | 5/ (spare) | 9 0 (open frame) |
+| Frame 1         | Frame 2       | Frame 3                |
+| :-------------: |:-------------:| :---------------------:|
+| X (strike)      | 5/ (spare)    | 9 0 (open frame)       |
 
 Frame 1 is (10 + 5 + 5) = 20
 
@@ -40,11 +35,11 @@ Frame 3 is (9 + 0) = 9
 
 This means the current running total is 48.
 
-The tenth frame in the game is a special case. If someone throws a
-strike or a spare then they get a fill ball. Fill balls exist to
-calculate the total of the 10th frame. Scoring a strike or spare on
-the fill ball does not give the player more fill balls. The total
-value of the 10th frame is the total number of pins knocked down.
+The tenth frame in the game is a special case.
+If someone throws a strike or a spare then they get a fill ball.
+Fill balls exist to calculate the total of the 10th frame.
+Scoring a strike or spare on the fill ball does not give the player more fill balls.
+The total value of the 10th frame is the total number of pins knocked down.
 
 For a tenth frame of X1/ (strike and a spare), the total value is 20.
 
@@ -52,8 +47,10 @@ For a tenth frame of XXX (three strikes), the total value is 30.
 
 ## Requirements
 
-Write code to keep track of the score of a game of bowling. It should
-support two operations:
+Write code to keep track of the score of a game of bowling.
+It should support two operations:
 
-- `roll(game: Game, knocked_pins: Int) -> Result(Game, Error)` is called each time the player rolls a ball. The first argument is the state of the game until now. The second argument is the number of knocked down pins.
-- `score(game: Game) -> Result(Int, Error)` is called only at the very end of the game. It recieves the state of the game and returns the total score for that game.
+- `roll(pins : int)` is called each time the player rolls a ball.
+  The argument is the number of pins knocked down.
+- `score() : int` is called only at the very end of the game.
+  It returns the total score for that game.

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -20,5 +20,7 @@
       "manifest.toml"
     ]
   },
-  "blurb": "Bowling is a game where players roll a heavy ball to knock down pins arranged in a triangle. Write code to keep track of the score of a game of bowling."
+  "blurb": "Score a bowling game.",
+  "source": "The Bowling Game Kata from UncleBob",
+  "source_url": "https://web.archive.org/web/20221001111000/http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
 }

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -1,0 +1,104 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[656ae006-25c2-438c-a549-f338e7ec7441]
+description = "should be able to score a game with all zeros"
+
+[f85dcc56-cd6b-4875-81b3-e50921e3597b]
+description = "should be able to score a game with no strikes or spares"
+
+[d1f56305-3ac2-4fe0-8645-0b37e3073e20]
+description = "a spare followed by zeros is worth ten points"
+
+[0b8c8bb7-764a-4287-801a-f9e9012f8be4]
+description = "points scored in the roll after a spare are counted twice"
+
+[4d54d502-1565-4691-84cd-f29a09c65bea]
+description = "consecutive spares each get a one roll bonus"
+
+[e5c9cf3d-abbe-4b74-ad48-34051b2b08c0]
+description = "a spare in the last frame gets a one roll bonus that is counted once"
+
+[75269642-2b34-4b72-95a4-9be28ab16902]
+description = "a strike earns ten points in a frame with a single roll"
+
+[037f978c-5d01-4e49-bdeb-9e20a2e6f9a6]
+description = "points scored in the two rolls after a strike are counted twice as a bonus"
+
+[1635e82b-14ec-4cd1-bce4-4ea14bd13a49]
+description = "consecutive strikes each get the two roll bonus"
+
+[e483e8b6-cb4b-4959-b310-e3982030d766]
+description = "a strike in the last frame gets a two roll bonus that is counted once"
+
+[9d5c87db-84bc-4e01-8e95-53350c8af1f8]
+description = "rolling a spare with the two roll bonus does not get a bonus roll"
+
+[576faac1-7cff-4029-ad72-c16bcada79b5]
+description = "strikes with the two roll bonus do not get bonus rolls"
+
+[efb426ec-7e15-42e6-9b96-b4fca3ec2359]
+description = "last two strikes followed by only last bonus with non strike points"
+include = false
+
+[72e24404-b6c6-46af-b188-875514c0377b]
+description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
+
+[62ee4c72-8ee8-4250-b794-234f1fec17b1]
+description = "all strikes is a perfect game"
+
+[1245216b-19c6-422c-b34b-6e4012d7459f]
+description = "rolls cannot score negative points"
+
+[5fcbd206-782c-4faa-8f3a-be5c538ba841]
+description = "a roll cannot score more than 10 points"
+
+[fb023c31-d842-422d-ad7e-79ce1db23c21]
+description = "two rolls in a frame cannot score more than 10 points"
+
+[6082d689-d677-4214-80d7-99940189381b]
+description = "bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[e9565fe6-510a-4675-ba6b-733a56767a45]
+description = "two bonus rolls after a strike in the last frame cannot score more than 10 points"
+
+[2f6acf99-448e-4282-8103-0b9c7df99c3d]
+description = "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike"
+
+[6380495a-8bc4-4cdb-a59f-5f0212dbed01]
+description = "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike"
+
+[2b2976ea-446c-47a3-9817-42777f09fe7e]
+description = "second bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[29220245-ac8d-463d-bc19-98a94cfada8a]
+description = "an unstarted game cannot be scored"
+
+[4473dc5d-1f86-486f-bf79-426a52ddc955]
+description = "an incomplete game cannot be scored"
+
+[2ccb8980-1b37-4988-b7d1-e5701c317df3]
+description = "cannot roll if game already has ten frames"
+
+[4864f09b-9df3-4b65-9924-c595ed236f1b]
+description = "bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[537f4e37-4b51-4d1c-97e2-986eb37b2ac1]
+description = "both bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[8134e8c1-4201-4197-bf9f-1431afcde4b9]
+description = "bonus roll for a spare in the last frame must be rolled before score can be calculated"
+
+[9d4a9a55-134a-4bad-bae8-3babf84bd570]
+description = "cannot roll after bonus roll for spare"
+
+[d3e02652-a799-4ae3-b53b-68582cc604be]
+description = "cannot roll after bonus rolls for strike"

--- a/exercises/practice/circular-buffer/.docs/instructions.md
+++ b/exercises/practice/circular-buffer/.docs/instructions.md
@@ -1,4 +1,4 @@
-# Description
+# Instructions
 
 A circular buffer, cyclic buffer or ring buffer is a data structure that uses a single, fixed-size buffer as if it were connected end-to-end.
 

--- a/exercises/practice/circular-buffer/.meta/tests.toml
+++ b/exercises/practice/circular-buffer/.meta/tests.toml
@@ -1,30 +1,52 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-[6466b30d-519c-438e-935d-388224ab5223]
-description = "year not divisible by 4 in common year"
+[28268ed4-4ff3-45f3-820e-895b44d53dfa]
+description = "reading empty buffer should fail"
 
-[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
-description = "year divisible by 2, not divisible by 4 in common year"
+[2e6db04a-58a1-425d-ade8-ac30b5f318f3]
+description = "can read an item just written"
 
-[4fe9b84c-8e65-489e-970b-856d60b8b78e]
-description = "year divisible by 4, not divisible by 100 in leap year"
+[90741fe8-a448-45ce-be2b-de009a24c144]
+description = "each item may only be read once"
 
-[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
-description = "year divisible by 4 and 5 is still a leap year"
+[be0e62d5-da9c-47a8-b037-5db21827baa7]
+description = "items are read in the order they are written"
 
-[78a7848f-9667-4192-ae53-87b30c9a02dd]
-description = "year divisible by 100, not divisible by 400 in common year"
+[2af22046-3e44-4235-bfe6-05ba60439d38]
+description = "full buffer can't be written to"
 
-[9d70f938-537c-40a6-ba19-f50739ce8bac]
-description = "year divisible by 100 but not by 3 is still not a leap year"
+[547d192c-bbf0-4369-b8fa-fc37e71f2393]
+description = "a read frees up capacity for another write"
 
-[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
-description = "year divisible by 400 in leap year"
+[04a56659-3a81-4113-816b-6ecb659b4471]
+description = "read position is maintained even across multiple writes"
 
-[57902c77-6fe9-40de-8302-587b5c27121e]
-description = "year divisible by 400 but not by 125 is still a leap year"
+[60c3a19a-81a7-43d7-bb0a-f07242b1111f]
+description = "items cleared out of buffer can't be read"
 
-[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
-description = "year divisible by 200, not divisible by 400 in common year"
+[45f3ae89-3470-49f3-b50e-362e4b330a59]
+description = "clear frees up capacity for another write"
+
+[e1ac5170-a026-4725-bfbe-0cf332eddecd]
+description = "clear does nothing on empty buffer"
+
+[9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b]
+description = "overwrite acts like write on non-full buffer"
+
+[880f916b-5039-475c-bd5c-83463c36a147]
+description = "overwrite replaces the oldest item on full buffer"
+
+[bfecab5b-aca1-4fab-a2b0-cd4af2b053c3]
+description = "overwrite replaces the oldest item remaining in buffer following a read"
+
+[9cebe63a-c405-437b-8b62-e3fdc1ecec5a]
+description = "initial clear does not affect wrapping around"

--- a/exercises/practice/difference-of-squares/.docs/instructions.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.md
@@ -8,10 +8,7 @@ The square of the sum of the first ten natural numbers is
 The sum of the squares of the first ten natural numbers is
 1² + 2² + ... + 10² = 385.
 
-Hence the difference between the square of the sum of the first
-ten natural numbers and the sum of the squares of the first ten
-natural numbers is 3025 - 385 = 2640.
+Hence the difference between the square of the sum of the first ten natural numbers and the sum of the squares of the first ten natural numbers is 3025 - 385 = 2640.
 
-You are not expected to discover an efficient solution to this yourself from
-first principles; research is allowed, indeed, encouraged. Finding the best
-algorithm for the problem is a key skill in software engineering.
+You are not expected to discover an efficient solution to this yourself from first principles; research is allowed, indeed, encouraged.
+Finding the best algorithm for the problem is a key skill in software engineering.

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -22,5 +22,5 @@
   },
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "source": "Problem 6 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=6"
+  "source_url": "https://projecteuler.net/problem=6"
 }

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "Square the sum of the numbers up to the given number -> square of sum 1"
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "Square the sum of the numbers up to the given number -> square of sum 5"
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "Square the sum of the numbers up to the given number -> square of sum 100"
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 1"
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 5"
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 100"
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "Subtract sum of squares from square of sums -> difference of squares 1"
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "Subtract sum of squares from square of sums -> difference of squares 5"
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "Subtract sum of squares from square of sums -> difference of squares 100"

--- a/exercises/practice/dominoes/.docs/instructions.md
+++ b/exercises/practice/dominoes/.docs/instructions.md
@@ -2,14 +2,12 @@
 
 Make a chain of dominoes.
 
-Compute a way to order a given set of dominoes in such a way that they form a
-correct domino chain (the dots on one half of a tile match the dots on the
-neighbouring half of an adjacent tile) and that dots on the halves of the
-tiles which don't have a neighbour (the first and last tile) match each other.
+Compute a way to order a given set of dominoes in such a way that they form a correct domino chain (the dots on one half of a stone match the dots on the neighboring half of an adjacent stone) and that dots on the halves of the stones which don't have a neighbor (the first and last stone) match each other.
 
-For example given the tiles `[2|1]`, `[2|3]` and `[1|3]` you should compute something
+For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
 like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.
 
-For tiles `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1] [1|2] [2|3]`'s first and last numbers are not the same. 4 != 3
+For stones `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1] [1|2] [2|3]`'s first and last numbers are not the same.
+4 != 3
 
-Some test cases may use duplicate tiles in a chain solution, assume that multiple Domino sets are being used.
+Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -20,5 +20,5 @@
       "manifest.toml"
     ]
   },
-  "blurb": "Make a chain of dominoes"
+  "blurb": "Make a chain of dominoes."
 }

--- a/exercises/practice/dominoes/.meta/tests.toml
+++ b/exercises/practice/dominoes/.meta/tests.toml
@@ -1,0 +1,58 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[31a673f2-5e54-49fe-bd79-1c1dae476c9c]
+description = "empty input = empty output"
+
+[4f99b933-367b-404b-8c6d-36d5923ee476]
+description = "singleton input = singleton output"
+
+[91122d10-5ec7-47cb-b759-033756375869]
+description = "singleton that can't be chained"
+
+[be8bc26b-fd3d-440b-8e9f-d698a0623be3]
+description = "three elements"
+
+[99e615c6-c059-401c-9e87-ad7af11fea5c]
+description = "can reverse dominoes"
+include = false
+
+[51f0c291-5d43-40c5-b316-0429069528c9]
+description = "can't be chained"
+include = false
+
+[9a75e078-a025-4c23-8c3a-238553657f39]
+description = "disconnected - simple"
+include = false
+
+[0da0c7fe-d492-445d-b9ef-1f111f07a301]
+description = "disconnected - double loop"
+include = false
+
+[b6087ff0-f555-4ea0-a71c-f9d707c5994a]
+description = "disconnected - single isolated"
+include = false
+
+[2174fbdc-8b48-4bac-9914-8090d06ef978]
+description = "need backtrack"
+include = false
+
+[167bb480-dfd1-4318-a20d-4f90adb4a09f]
+description = "separate loops"
+include = false
+
+[cd061538-6046-45a7-ace9-6708fe8f6504]
+description = "nine elements"
+include = false
+
+[44704c7c-3adb-4d98-bd30-f45527cf8b49]
+description = "separate three-domino loops"
+include = false

--- a/exercises/practice/forth/.docs/instructions.md
+++ b/exercises/practice/forth/.docs/instructions.md
@@ -2,25 +2,22 @@
 
 Implement an evaluator for a very simple subset of Forth.
 
-[Forth](https://en.wikipedia.org/wiki/Forth_%28programming_language%29)
-is a stack-based programming language. Implement a very basic evaluator
-for a small subset of Forth.
+[Forth][forth]
+is a stack-based programming language.
+Implement a very basic evaluator for a small subset of Forth.
 
 Your evaluator has to support the following words:
 
 - `+`, `-`, `*`, `/` (integer arithmetic)
 - `DUP`, `DROP`, `SWAP`, `OVER` (stack manipulation)
 
-Your evaluator also has to support defining new words using the
-customary syntax: `: word-name definition ;`.
+Your evaluator also has to support defining new words using the customary syntax: `: word-name definition ;`.
 
-To keep things simple the only data type you need to support is signed
-integers of at least 16 bits size.
+To keep things simple the only data type you need to support is signed integers of at least 16 bits size.
 
-You should use the following rules for the syntax: a number is a
-sequence of one or more (ASCII) digits, a word is a sequence of one or
-more letters, digits, symbols or punctuation that is not a number.
-(Forth probably uses slightly different rules, but this is close
-enough.)
+You should use the following rules for the syntax: a number is a sequence of one or more (ASCII) digits, a word is a sequence of one or more letters, digits, symbols or punctuation that is not a number.
+(Forth probably uses slightly different rules, but this is close enough.)
 
 Words are case-insensitive.
+
+[forth]: https://en.wikipedia.org/wiki/Forth_%28programming_language%29

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -15,5 +15,5 @@
       "manifest.toml"
     ]
   },
-  "blurb": "Implement an evaluator for a very simple subset of Forth"
+  "blurb": "Implement an evaluator for a very simple subset of Forth."
 }

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -1,0 +1,184 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[9962203f-f00a-4a85-b404-8a8ecbcec09d]
+description = "parsing and numbers -> numbers just get pushed onto the stack"
+
+[fd7a8da2-6818-4203-a866-fed0714e7aa0]
+description = "parsing and numbers -> pushes negative numbers onto the stack"
+include = false
+
+[9e69588e-a3d8-41a3-a371-ea02206c1e6e]
+description = "addition -> can add two numbers"
+include = false
+
+[52336dd3-30da-4e5c-8523-bdf9a3427657]
+description = "addition -> errors if there is nothing on the stack"
+include = false
+
+[06efb9a4-817a-435e-b509-06166993c1b8]
+description = "addition -> errors if there is only one value on the stack"
+include = false
+
+[09687c99-7bbc-44af-8526-e402f997ccbf]
+description = "subtraction -> can subtract two numbers"
+include = false
+
+[5d63eee2-1f7d-4538-b475-e27682ab8032]
+description = "subtraction -> errors if there is nothing on the stack"
+include = false
+
+[b3cee1b2-9159-418a-b00d-a1bb3765c23b]
+description = "subtraction -> errors if there is only one value on the stack"
+include = false
+
+[5df0ceb5-922e-401f-974d-8287427dbf21]
+description = "multiplication -> can multiply two numbers"
+include = false
+
+[9e004339-15ac-4063-8ec1-5720f4e75046]
+description = "multiplication -> errors if there is nothing on the stack"
+include = false
+
+[8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
+description = "multiplication -> errors if there is only one value on the stack"
+include = false
+
+[e74c2204-b057-4cff-9aa9-31c7c97a93f5]
+description = "division -> can divide two numbers"
+include = false
+
+[54f6711c-4b14-4bb0-98ad-d974a22c4620]
+description = "division -> performs integer division"
+include = false
+
+[a5df3219-29b4-4d2f-b427-81f82f42a3f1]
+description = "division -> errors if dividing by zero"
+
+[1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
+description = "division -> errors if there is nothing on the stack"
+include = false
+
+[d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
+description = "division -> errors if there is only one value on the stack"
+include = false
+
+[ee28d729-6692-4a30-b9be-0d830c52a68c]
+description = "combined arithmetic -> addition and subtraction"
+
+[40b197da-fa4b-4aca-a50b-f000d19422c1]
+description = "combined arithmetic -> multiplication and division"
+
+[c5758235-6eef-4bf6-ab62-c878e50b9957]
+description = "dup -> copies a value on the stack"
+
+[f6889006-5a40-41e7-beb3-43b09e5a22f4]
+description = "dup -> copies the top value on the stack"
+
+[40b7569c-8401-4bd4-a30d-9adf70d11bc4]
+description = "dup -> errors if there is nothing on the stack"
+
+[1971da68-1df2-4569-927a-72bf5bb7263c]
+description = "drop -> removes the top value on the stack if it is the only one"
+
+[8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
+description = "drop -> removes the top value on the stack if it is not the only one"
+
+[6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
+description = "drop -> errors if there is nothing on the stack"
+
+[3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
+description = "swap -> swaps the top two values on the stack if they are the only ones"
+
+[8ce869d5-a503-44e4-ab55-1da36816ff1c]
+description = "swap -> swaps the top two values on the stack if they are not the only ones"
+
+[74ba5b2a-b028-4759-9176-c5c0e7b2b154]
+description = "swap -> errors if there is nothing on the stack"
+
+[dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
+description = "swap -> errors if there is only one value on the stack"
+
+[a2654074-ba68-4f93-b014-6b12693a8b50]
+description = "over -> copies the second element if there are only two"
+
+[c5b51097-741a-4da7-8736-5c93fa856339]
+description = "over -> copies the second element if there are more than two"
+
+[6e1703a6-5963-4a03-abba-02e77e3181fd]
+description = "over -> errors if there is nothing on the stack"
+
+[ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
+description = "over -> errors if there is only one value on the stack"
+
+[ed45cbbf-4dbf-4901-825b-54b20dbee53b]
+description = "user-defined words -> can consist of built-in words"
+
+[2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
+description = "user-defined words -> execute in the right order"
+include = false
+
+[9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
+description = "user-defined words -> can override other user-defined words"
+
+[669db3f3-5bd6-4be0-83d1-618cd6e4984b]
+description = "user-defined words -> can override built-in words"
+
+[588de2f0-c56e-4c68-be0b-0bb1e603c500]
+description = "user-defined words -> can override built-in operators"
+include = false
+
+[ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
+description = "user-defined words -> can use different words with the same name"
+include = false
+
+[53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
+description = "user-defined words -> can define word that uses word with the same name"
+include = false
+
+[35958cee-a976-4a0f-9378-f678518fa322]
+description = "user-defined words -> cannot redefine non-negative numbers"
+
+[df5b2815-3843-4f55-b16c-c3ed507292a7]
+description = "user-defined words -> cannot redefine negative numbers"
+include = false
+
+[5180f261-89dd-491e-b230-62737e09806f]
+description = "user-defined words -> errors if executing a non-existent word"
+include = false
+
+[3c8bfef3-edbb-49c1-9993-21d4030043cb]
+description = "user-defined words -> only defines locally"
+include = false
+
+[7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
+description = "case-insensitivity -> DUP is case-insensitive"
+include = false
+
+[339ed30b-f5b4-47ff-ab1c-67591a9cd336]
+description = "case-insensitivity -> DROP is case-insensitive"
+include = false
+
+[ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
+description = "case-insensitivity -> SWAP is case-insensitive"
+include = false
+
+[acdc3a49-14c8-4cc2-945d-11edee6408fa]
+description = "case-insensitivity -> OVER is case-insensitive"
+include = false
+
+[5934454f-a24f-4efc-9fdd-5794e5f0c23c]
+description = "case-insensitivity -> user-defined words are case-insensitive"
+include = false
+
+[037d4299-195f-4be7-a46d-f07ca6280a06]
+description = "case-insensitivity -> definitions are case-insensitive"
+include = false

--- a/exercises/practice/hello-world/.docs/instructions.md
+++ b/exercises/practice/hello-world/.docs/instructions.md
@@ -1,15 +1,16 @@
 # Instructions
 
-The classical introductory exercise. Just say "Hello, World!".
+The classical introductory exercise.
+Just say "Hello, World!".
 
-["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
-the traditional first program for beginning programming in a new language
-or environment.
+["Hello, World!"][hello-world] is the traditional first program for beginning programming in a new language or environment.
 
 The objectives are simple:
 
-- Write a function that returns the string "Hello, World!".
+- Modify the provided code so that it produces the string "Hello, World!".
 - Run the test suite and make sure that it succeeds.
 - Submit your solution and check it at the website.
 
 If everything goes well, you will be ready to fetch your first real exercise.
+
+[hello-world]: https://en.wikipedia.org/wiki/%22Hello,_world!%22_program

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -21,7 +21,7 @@
       "manifest.toml"
     ]
   },
-  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",
   "source": "This is an exercise to introduce users to using Exercism",
-  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
+  "source_url": "https://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
 }

--- a/exercises/practice/leap/.docs/instructions.md
+++ b/exercises/practice/leap/.docs/instructions.md
@@ -10,15 +10,13 @@ on every year that is evenly divisible by 4
     unless the year is also evenly divisible by 400
 ```
 
-For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
-year, but 2000 is.
+For example, 1997 is not a leap year, but 1996 is.
+1900 is not a leap year, but 2000 is.
 
 ## Notes
 
-Though our exercise adopts some very simple rules, there is more to
-learn!
+Though our exercise adopts some very simple rules, there is more to learn!
 
-For a delightful, four minute explanation of the whole leap year
-phenomenon, go watch [this youtube video][video].
+For a delightful, four minute explanation of the whole leap year phenomenon, go watch [this youtube video][video].
 
-[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+[video]: https://www.youtube.com/watch?v=xX96xng7sAE

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -18,6 +18,6 @@
     ]
   },
   "blurb": "Given a year, report if it is a leap year.",
-  "source": "JavaRanch Cattle Drive, exercise 3",
-  "source_url": "http://www.javaranch.com/leap.jsp"
+  "source": "CodeRanch Cattle Drive, Assignment 3",
+  "source_url": "https://coderanch.com/t/718816/Leap"
 }

--- a/exercises/practice/pangram/.docs/instructions.md
+++ b/exercises/practice/pangram/.docs/instructions.md
@@ -1,4 +1,4 @@
-# Description
+# Instructions
 
 Determine if a sentence is a pangram.
 A pangram (Greek: παν γράμμα, pan gramma, "every letter") is a sentence using every letter of the alphabet at least once.

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,0 +1,45 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
+
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
+
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
+
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
+
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
+
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
+
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
+
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
+
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
+
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"
+include = false
+
+[7138e389-83e4-4c6e-8413-1e40a0076951]
+description = "a-m and A-M are 26 different characters but not a pangram"
+reimplements = "2577bf54-83c8-402d-a64b-a2c0f7bb213a"

--- a/exercises/practice/pascals-triangle/.docs/instructions.md
+++ b/exercises/practice/pascals-triangle/.docs/instructions.md
@@ -2,8 +2,7 @@
 
 Compute Pascal's triangle up to a given number of rows.
 
-In Pascal's Triangle each number is computed by adding the numbers to
-the right and left of the current position in the previous row.
+In Pascal's Triangle each number is computed by adding the numbers to the right and left of the current position in the previous row.
 
 ```text
     1

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -22,5 +22,5 @@
   },
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "source": "Pascal's Triangle at Wolfram Math World",
-  "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"
+  "source_url": "https://www.wolframalpha.com/input/?i=Pascal%27s+triangle"
 }

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[9920ce55-9629-46d5-85d6-4201f4a4234d]
+description = "zero rows"
+include = false
+
+[70d643ce-a46d-4e93-af58-12d88dd01f21]
+description = "single row"
+
+[a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd]
+description = "two rows"
+
+[97206a99-79ba-4b04-b1c5-3c0fa1e16925]
+description = "three rows"
+
+[565a0431-c797-417c-a2c8-2935e01ce306]
+description = "four rows"
+
+[06f9ea50-9f51-4eb2-b9a9-c00975686c27]
+description = "five rows"
+
+[c3912965-ddb4-46a9-848e-3363e6b00b13]
+description = "six rows"
+include = false
+
+[6cb26c66-7b57-4161-962c-81ec8c99f16b]
+description = "ten rows"
+include = false

--- a/exercises/practice/protein-translation/.docs/instructions.md
+++ b/exercises/practice/protein-translation/.docs/instructions.md
@@ -1,4 +1,4 @@
-# Description
+# Instructions
 
 Translate RNA sequences into proteins.
 

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -1,6 +1,102 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-[af9ffe10-dc13-42d8-a742-e7bdafac449d]
-description = "Say Hi!"
+[2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98]
+description = "Empty RNA sequence results in no proteins"
+include = false
+
+[96d3d44f-34a2-4db4-84cd-fff523e069be]
+description = "Methionine RNA sequence"
+
+[1b4c56d8-d69f-44eb-be0e-7b17546143d9]
+description = "Phenylalanine RNA sequence 1"
+
+[81b53646-bd57-4732-b2cb-6b1880e36d11]
+description = "Phenylalanine RNA sequence 2"
+
+[42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4]
+description = "Leucine RNA sequence 1"
+
+[ac5edadd-08ed-40a3-b2b9-d82bb50424c4]
+description = "Leucine RNA sequence 2"
+
+[8bc36e22-f984-44c3-9f6b-ee5d4e73f120]
+description = "Serine RNA sequence 1"
+
+[5c3fa5da-4268-44e5-9f4b-f016ccf90131]
+description = "Serine RNA sequence 2"
+
+[00579891-b594-42b4-96dc-7ff8bf519606]
+description = "Serine RNA sequence 3"
+
+[08c61c3b-fa34-4950-8c4a-133945570ef6]
+description = "Serine RNA sequence 4"
+
+[54e1e7d8-63c0-456d-91d2-062c72f8eef5]
+description = "Tyrosine RNA sequence 1"
+
+[47bcfba2-9d72-46ad-bbce-22f7666b7eb1]
+description = "Tyrosine RNA sequence 2"
+
+[3a691829-fe72-43a7-8c8e-1bd083163f72]
+description = "Cysteine RNA sequence 1"
+
+[1b6f8a26-ca2f-43b8-8262-3ee446021767]
+description = "Cysteine RNA sequence 2"
+
+[1e91c1eb-02c0-48a0-9e35-168ad0cb5f39]
+description = "Tryptophan RNA sequence"
+
+[e547af0b-aeab-49c7-9f13-801773a73557]
+description = "STOP codon RNA sequence 1"
+
+[67640947-ff02-4f23-a2ef-816f8a2ba72e]
+description = "STOP codon RNA sequence 2"
+
+[9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
+description = "STOP codon RNA sequence 3"
+
+[f4d9d8ee-00a8-47bf-a1e3-1641d4428e54]
+description = "Sequence of two protein codons translates into proteins"
+
+[dd22eef3-b4f1-4ad6-bb0b-27093c090a9d]
+description = "Sequence of two different protein codons translates into proteins"
+
+[d0f295df-fb70-425c-946c-ec2ec185388e]
+description = "Translate RNA strand into correct protein list"
+
+[e30e8505-97ec-4e5f-a73e-5726a1faa1f4]
+description = "Translation stops if STOP codon at beginning of sequence"
+
+[5358a20b-6f4c-4893-bce4-f929001710f3]
+description = "Translation stops if STOP codon at end of two-codon sequence"
+
+[ba16703a-1a55-482f-bb07-b21eef5093a3]
+description = "Translation stops if STOP codon at end of three-codon sequence"
+
+[4089bb5a-d5b4-4e71-b79e-b8d1f14a2911]
+description = "Translation stops if STOP codon in middle of three-codon sequence"
+
+[2c2a2a60-401f-4a80-b977-e0715b23b93d]
+description = "Translation stops if STOP codon in middle of six-codon sequence"
+
+[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
+description = "Non-existing codon can't translate"
+
+[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
+description = "Unknown amino acids, not part of a codon, can't translate"
+
+[9d73899f-e68e-4291-b1e2-7bf87c00f024]
+description = "Incomplete RNA sequence can't translate"
+
+[43945cf7-9968-402d-ab9f-b8a28750b050]
+description = "Incomplete RNA sequence can translate if valid until a STOP codon"
+include = false

--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -3,8 +3,8 @@
 If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
 For this exercise, you need to know two things about them:
 
-* Each resistor has a resistance value.
-* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
 
 To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
 Each band has a position and a numeric value.
@@ -27,9 +27,13 @@ These colors are encoded as follows:
 - White: 9
 
 The goal of this exercise is to create a way:
+
 - to look up the numerical value associated with a particular color band
 - to list the different band colors
 
-Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array:
+Better Be Right Or Your Great Big Values Go Wrong.
 
-More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article][e-color-code].
+
+[e-color-code]: https://en.wikipedia.org/wiki/Electronic_color_code

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -20,7 +20,7 @@
       "manifest.toml"
     ]
   },
-  "blurb": "Convert a resistor band's color to its numeric representation",
+  "blurb": "Convert a resistor band's color to its numeric representation.",
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
 }

--- a/exercises/practice/rna-transcription/.docs/instructions.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.md
@@ -1,4 +1,4 @@
-# Description
+# Instructions
 
 Given a DNA strand, return its RNA complement (per RNA transcription).
 

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -2,17 +2,15 @@
 
 Write a function to convert from normal numbers to Roman Numerals.
 
-The Romans were a clever bunch. They conquered most of Europe and ruled
-it for hundreds of years. They invented concrete and straight roads and
-even bikinis. One thing they never discovered though was the number
-zero. This made writing and dating extensive histories of their exploits
-slightly more challenging, but the system of numbers they came up with
-is still in use today. For example the BBC uses Roman numerals to date
-their programs.
+The Romans were a clever bunch.
+They conquered most of Europe and ruled it for hundreds of years.
+They invented concrete and straight roads and even bikinis.
+One thing they never discovered though was the number zero.
+This made writing and dating extensive histories of their exploits slightly more challenging, but the system of numbers they came up with is still in use today.
+For example the BBC uses Roman numerals to date their programs.
 
-The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
-these letters have lots of straight lines and are hence easy to hack
-into stone tablets).
+The Romans wrote numbers using letters - I, V, X, L, C, D, M.
+(notice these letters have lots of straight lines and are hence easy to hack into stone tablets).
 
 ```text
  1  => I
@@ -23,9 +21,7 @@ into stone tablets).
 The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
-Wikipedia says: Modern Roman numerals ... are written by expressing each
-digit separately starting with the left most digit and skipping any
-digit with a value of zero.
+Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any digit with a value of zero.
 
 To see this in practice, consider the example of 1990.
 

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -20,5 +20,7 @@
       "manifest.toml"
     ]
   },
-  "blurb": "Write a function to convert numbers to Roman Numerals."
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
+  "source": "The Roman Numeral Kata",
+  "source_url": "https://codingdojo.org/kata/RomanNumerals/"
 }

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,0 +1,91 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is I"
+
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is II"
+
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is III"
+
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4 is IV"
+
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is V"
+
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6 is VI"
+
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9 is IX"
+
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "27 is XXVII"
+
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is XLVIII"
+
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is XLIX"
+
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "59 is LIX"
+
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "93 is XCIII"
+
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "141 is CXLI"
+
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "163 is CLXIII"
+
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "402 is CDII"
+
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "575 is DLXXV"
+
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "911 is CMXI"
+
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1024 is MXXIV"
+
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"
+
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+include = false
+
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
+
+[efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
+description = "1666 is MDCLXVI"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+include = false
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"
+include = false

--- a/exercises/practice/two-fer/.docs/instructions.md
+++ b/exercises/practice/two-fer/.docs/instructions.md
@@ -1,6 +1,7 @@
 # Instructions
 
-`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+`Two-fer` or `2-fer` is short for two for one.
+One for you and one for me.
 
 Given a name, return a string with the message:
 

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -20,6 +20,6 @@
       "manifest.toml"
     ]
   },
-  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
+  "blurb": "Create a sentence of the form \"One for X, one for me.\".",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }


### PR DESCRIPTION
I ran the following 3 commands
```bash
➜  gleam git:(jie-sync) ✗ bin/configlet sync --metadata --update --yes    
➜  gleam git:(jie-sync) ✗ bin/configlet sync --docs --update --yes    
➜  gleam git:(jie-sync) ✗ bin/configlet sync --tests --update
```

For the metadata and docs, it's best to trust configlet.

For the tests, the command goes through all exercise, checks `tests.toml` and asks if each exercise missing has been implemented. I checked the test files and answered as accurately as I could (there were a lot of tests).
In general, this data is very useful for when test data gets updated upstream, it makes the track updates very simple.

When tests are not implemented, they are marked as `include = false` in the file. Sometimes there are good reasons to not implement a case (for example, some test cases check for immutability, which makes no sense in Gleam) and in those cases, it's good practice to leave a reason via `comment = "Gleam is immutable"`.

I noticed a bunch of cases were missing (I'm guessing some test files were copied from some other tracks with missing data?) but I didn't implement them or add justifications. We might want to open an issue to track that if you want to address that at some point (it's low priority though).