### PR TITLE
Update two-fer to match canonical data

### DIFF
--- a/exercises/practice/two-fer/.meta/example.gleam
+++ b/exercises/practice/two-fer/.meta/example.gleam
@@ -1,5 +1,5 @@
 import gleam/option.{Option}
 
 pub fn two_fer(name: Option(String)) -> String {
-  "One for " <> option.unwrap(name, "you") <> ", one for me"
+  "One for " <> option.unwrap(name, "you") <> ", one for me."
 }

--- a/exercises/practice/two-fer/test/two_fer_test.gleam
+++ b/exercises/practice/two-fer/test/two_fer_test.gleam
@@ -7,12 +7,17 @@ pub fn main() {
   gleeunit.main()
 }
 
-pub fn no_name_test() {
+pub fn no_name_given_test() {
   two_fer(None)
-  |> should.equal("One for you, one for me")
+  |> should.equal("One for you, one for me.")
 }
 
-pub fn with_name_test() {
-  two_fer(Some("Gilberto Barros"))
-  |> should.equal("One for Gilberto Barros, one for me")
+pub fn a_name_given_test() {
+  two_fer(Some("Alice"))
+  |> should.equal("One for Alice, one for me.")
+}
+
+pub fn another_name_given_test() {
+  two_fer(Some("Bob"))
+  |> should.equal("One for Bob, one for me.")
 }


### PR DESCRIPTION
This updates two-fer to match the canonical specs in the problem-specifications repository.

I hesitated about making it Alice instead of Gilberto Barros
https://github.com/exercism/problem-specifications/blob/51fcbc35abc4ac8d0394d3186f10b2fed04ef3ce/exercises/two-fer/canonical-data.json#L18
because there's no reason why it can't be Gilberto, and I like the creativity of it.

I'd be happy to put that back if you prefer it.