### PR TITLE
Tweak leap tests to match problem-specifications

### DIFF
--- a/exercises/practice/leap/test/leap_test.gleam
+++ b/exercises/practice/leap/test/leap_test.gleam
@@ -6,27 +6,47 @@ pub fn main() {
   gleeunit.main()
 }
 
-pub fn year_2015_test() {
+pub fn year_not_divisible_by_4_in_common_year_test() {
   leap.is_leap_year(2015)
   |> should.be_false
 }
 
-pub fn year_1996_test() {
+pub fn year_divisible_by_2_not_divisible_by_4_in_common_year_test() {
+  leap.is_leap_year(1970)
+  |> should.be_false
+}
+
+pub fn year_divisible_by_4_not_divisible_by_100_in_leap_year_test() {
   leap.is_leap_year(1996)
   |> should.be_true
 }
 
-pub fn year_2100_test() {
+pub fn year_divisible_by_4_and_5_is_still_a_leap_year_test() {
+  leap.is_leap_year(1960)
+  |> should.be_true
+}
+
+pub fn year_divisible_by_100_not_divisible_by_400_in_common_year_test() {
   leap.is_leap_year(2100)
   |> should.be_false
 }
 
-pub fn year_2000_test() {
+pub fn year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year_test() {
+  leap.is_leap_year(1900)
+  |> should.be_false
+}
+
+pub fn year_divisible_by_400_is_leap_year_test() {
   leap.is_leap_year(2000)
   |> should.be_true
 }
 
-pub fn year_1800_test() {
+pub fn year_divisible_by_400_but_not_by_125_is_still_a_leap_year_test() {
+  leap.is_leap_year(2400)
+  |> should.be_true
+}
+
+pub fn year_divisible_by_200_not_divisible_by_400_in_common_year_test() {
   leap.is_leap_year(1800)
   |> should.be_false
 }


### PR DESCRIPTION
This updates the tests in leap to match the tests specified in the
tests.toml file, which come from the canonical-data.json in the
problem-specifications repository.
