### PR TITLE
Update anagram to match canonical data

### DIFF
--- a/exercises/practice/anagram/test/anagram_test.gleam
+++ b/exercises/practice/anagram/test/anagram_test.gleam
@@ -11,27 +11,17 @@ pub fn no_matches_test() {
   |> should.equal([])
 }
 
-pub fn simple_test() {
-  find_anagrams("ant", ["tan", "stand", "at"])
-  |> should.equal(["tan"])
-}
-
-pub fn no_false_positive_test() {
-  find_anagrams("galea", ["eagle"])
+pub fn does_not_detect_anagram_subsets_test() {
+  find_anagrams("good", ["dog", "goody"])
   |> should.equal([])
 }
 
-pub fn no_superset_or_subset_test() {
-  find_anagrams("good", ["goody", "god"])
-  |> should.equal([])
-}
-
-pub fn single_test() {
+pub fn detects_anagram_test() {
   find_anagrams("listen", ["enlists", "google", "inlets", "banana"])
   |> should.equal(["inlets"])
 }
 
-pub fn multiple_test() {
+pub fn detects_three_anagrams_test() {
   find_anagrams(
     "allergy",
     ["gallery", "ballerina", "regally", "clergy", "largely", "leading"],
@@ -39,12 +29,7 @@ pub fn multiple_test() {
   |> should.equal(["gallery", "regally", "largely"])
 }
 
-pub fn case_insensitive_test() {
+pub fn detects_anagrams_case_insensitively_test() {
   find_anagrams("Orchestra", ["cashregister", "Carthorse", "radishes"])
   |> should.equal(["Carthorse"])
-}
-
-pub fn no_self_detection_test() {
-  find_anagrams("banana", ["Banana"])
-  |> should.equal([])
 }


### PR DESCRIPTION
This updates the anagram tests to match the tests listed in the
tests.toml. This is taken from the canonical-data.json file in
the problem-specifications repo.
