### PR TITLE
Reset tests.toml for anagram exercise

### DIFF
--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -3,7 +3,8 @@
     "massivefermion"
   ],
   "contributors": [
-    "lpil"
+    "lpil",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -18,7 +18,6 @@ include = false
 
 [03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
 description = "detects two anagrams"
-include = false
 reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
@@ -32,30 +31,24 @@ description = "detects three anagrams"
 
 [78487770-e258-4e1f-a646-8ece10950d90]
 description = "detects multiple anagrams with different case"
-include = false
 
 [1d0ab8aa-362f-49b7-9902-3d0c668d557b]
 description = "does not detect non-anagrams with identical checksum"
-include = false
 
 [9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
 description = "detects anagrams case-insensitively"
 
 [b248e49f-0905-48d2-9c8d-bd02d8c3e392]
 description = "detects anagrams using case-insensitive subject"
-include = false
 
 [f367325c-78ec-411c-be76-e79047f4bd54]
 description = "detects anagrams using case-insensitive possible matches"
-include = false
 
 [7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
 description = "does not detect an anagram if the original word is repeated"
-include = false
 
 [9878a1c9-d6ea-4235-ae51-3ea2befd6842]
 description = "anagrams must use all letters exactly once"
-include = false
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
@@ -63,17 +56,14 @@ include = false
 
 [68934ed0-010b-4ef9-857a-20c9012d1ebf]
 description = "words are not anagrams of themselves"
-include = false
 reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
 description = "words are not anagrams of themselves even if letter case is partially different"
-include = false
 reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
 description = "words are not anagrams of themselves even if letter case is completely different"
-include = false
 reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
@@ -82,5 +72,4 @@ include = false
 
 [33d3f67e-fbb9-49d3-a90e-0beb00861da7]
 description = "words other than themselves can be anagrams"
-include = false
 reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"

--- a/exercises/practice/anagram/test/anagram_test.gleam
+++ b/exercises/practice/anagram/test/anagram_test.gleam
@@ -11,6 +11,11 @@ pub fn no_matches_test() {
   |> should.equal([])
 }
 
+pub fn detects_two_anagrams_test() {
+  find_anagrams("solemn", ["lemons", "cherry", "melons"])
+  |> should.equal(["lemons", "melons"])
+}
+
 pub fn does_not_detect_anagram_subsets_test() {
   find_anagrams("good", ["dog", "goody"])
   |> should.equal([])
@@ -29,7 +34,57 @@ pub fn detects_three_anagrams_test() {
   |> should.equal(["gallery", "regally", "largely"])
 }
 
+pub fn detects_multiple_anagrams_with_different_case_test() {
+  find_anagrams("nose", ["Eons", "ONES"])
+  |> should.equal(["Eons", "ONES"])
+}
+
+pub fn does_not_detect_non_anagrams_with_identical_checksum_test() {
+  find_anagrams("mass", ["last"])
+  |> should.equal([])
+}
+
 pub fn detects_anagrams_case_insensitively_test() {
   find_anagrams("Orchestra", ["cashregister", "Carthorse", "radishes"])
   |> should.equal(["Carthorse"])
+}
+
+pub fn detects_anagrams_using_case_insensitive_subject_test() {
+  find_anagrams("Orchestra", ["cashregister", "carthorse", "radishes"])
+  |> should.equal(["carthorse"])
+}
+
+pub fn detects_anagrams_using_case_insensitive_possible_matches_test() {
+  find_anagrams("orchestra", ["cashregister", "Carthorse", "radishes"])
+  |> should.equal(["Carthorse"])
+}
+
+pub fn does_not_detect_an_anagram_if_the_original_word_is_repeated_test() {
+  find_anagrams("go", ["go Go GO"])
+  |> should.equal([])
+}
+
+pub fn anagrams_must_use_all_letters_exactly_once_test() {
+  find_anagrams("tapper", ["patter"])
+  |> should.equal([])
+}
+
+pub fn words_are_not_anagrams_of_themselves_test() {
+  find_anagrams("BANANA", ["BANANA"])
+  |> should.equal([])
+}
+
+pub fn words_are_not_anagrams_of_themselves_even_if_letter_case_is_partially_different_test() {
+  find_anagrams("BANANA", ["Banana"])
+  |> should.equal([])
+}
+
+pub fn words_are_not_anagrams_of_themselves_even_if_letter_case_is_completely_different_test() {
+  find_anagrams("BANANA", ["banana"])
+  |> should.equal([])
+}
+
+pub fn words_other_than_themselves_can_be_anagrams_test() {
+  find_anagrams("LISTEN", ["LISTEN", "Silent"])
+  |> should.equal(["Silent"])
 }


### PR DESCRIPTION
I updated the anagram test suite in #144 to match the
canonical-data.json file more closely, but I wasn't aware of
the open issue #134, so I didn't put in the tests that said
they were ignored.

This removes the 'include = false' from the tests.toml (except
in the case of re-implemented tests) and adds the missing test
cases.
