### PR TITLE
Update roman-numerals tests

### DIFF
--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -3,7 +3,8 @@
     "massivefermion"
   ],
   "contributors": [
-    "lpil"
+    "lpil",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -71,7 +71,6 @@ description = "16 is XVI"
 
 [4465ffd5-34dc-44f3-ada5-56f5007b6dad]
 description = "66 is LXVI"
-include = false
 
 [902ad132-0b4d-40e3-8597-ba5ed611dd8d]
 description = "166 is CLXVI"
@@ -84,8 +83,6 @@ description = "1666 is MDCLXVI"
 
 [3bc4b41c-c2e6-49d9-9142-420691504336]
 description = "3001 is MMMI"
-include = false
 
 [4e18e96b-5fbb-43df-a91b-9cb511fe0856]
 description = "3999 is MMMCMXCIX"
-include = false

--- a/exercises/practice/roman-numerals/test/roman_numerals_test.gleam
+++ b/exercises/practice/roman-numerals/test/roman_numerals_test.gleam
@@ -6,162 +6,132 @@ pub fn main() {
   gleeunit.main()
 }
 
-pub fn number_1_test() {
+pub fn number_1_is_i_test() {
   convert(1)
   |> should.equal("I")
 }
 
-pub fn number_2_test() {
+pub fn number_2_is_ii_test() {
   convert(2)
   |> should.equal("II")
 }
 
-pub fn number_3_test() {
+pub fn number_3_is_iii_test() {
   convert(3)
   |> should.equal("III")
 }
 
-pub fn number_4_test() {
+pub fn number_4_is_iv_test() {
   convert(4)
   |> should.equal("IV")
 }
 
-pub fn number_5_test() {
+pub fn number_5_is_v_test() {
   convert(5)
   |> should.equal("V")
 }
 
-pub fn number_6_test() {
+pub fn number_6_is_vi_test() {
   convert(6)
   |> should.equal("VI")
 }
 
-pub fn number_9_test() {
+pub fn number_9_is_ix_test() {
   convert(9)
   |> should.equal("IX")
 }
 
-pub fn number_16_test() {
+pub fn number_16_is_xvi_test() {
   convert(16)
   |> should.equal("XVI")
 }
 
-pub fn number_27_test() {
+pub fn number_27_is_xxvii_test() {
   convert(27)
   |> should.equal("XXVII")
 }
 
-pub fn number_32_test() {
-  convert(32)
-  |> should.equal("XXXII")
-}
-
-pub fn number_39_test() {
-  convert(39)
-  |> should.equal("XXXIX")
-}
-
-pub fn number_48_test() {
+pub fn number_48_is_xlviii_test() {
   convert(48)
   |> should.equal("XLVIII")
 }
 
-pub fn number_49_test() {
+pub fn number_49_is_xlix_test() {
   convert(49)
   |> should.equal("XLIX")
 }
 
-pub fn number_59_test() {
+pub fn number_59_is_lix_test() {
   convert(59)
   |> should.equal("LIX")
 }
 
-pub fn number_64_test() {
-  convert(64)
-  |> should.equal("LXIV")
+pub fn number_66_is_lxvi_test() {
+  convert(66)
+  |> should.equal("LXVI")
 }
 
-pub fn number_93_test() {
+pub fn number_93_is_xciii_test() {
   convert(93)
   |> should.equal("XCIII")
 }
 
-pub fn number_128_test() {
-  convert(128)
-  |> should.equal("CXXVIII")
-}
-
-pub fn number_141_test() {
+pub fn number_141_is_cxli_test() {
   convert(141)
   |> should.equal("CXLI")
 }
 
-pub fn number_163_test() {
+pub fn number_163_is_clxiii_test() {
   convert(163)
   |> should.equal("CLXIII")
 }
 
-pub fn number_246_test() {
-  convert(246)
-  |> should.equal("CCXLVI")
+pub fn number_166_is_clxvi_test() {
+  convert(166)
+  |> should.equal("CLXVI")
 }
 
-pub fn number_402_test() {
+pub fn number_402_is_cdii_test() {
   convert(402)
   |> should.equal("CDII")
 }
 
-pub fn number_575_test() {
+pub fn number_575_is_dlxxv_test() {
   convert(575)
   |> should.equal("DLXXV")
 }
 
-pub fn number_666_test() {
+pub fn number_666_is_dclxvi_test() {
   convert(666)
   |> should.equal("DCLXVI")
 }
 
-pub fn number_789_test() {
-  convert(789)
-  |> should.equal("DCCLXXXIX")
-}
-
-pub fn number_911_test() {
+pub fn number_911_is_cmxi_test() {
   convert(911)
   |> should.equal("CMXI")
 }
 
-pub fn number_1024_test() {
+pub fn number_1024_is_mxxiv_test() {
   convert(1024)
   |> should.equal("MXXIV")
 }
 
-pub fn number_1666_test() {
+pub fn number_1666_is_mdclxvi_test() {
   convert(1666)
   |> should.equal("MDCLXVI")
 }
 
-pub fn number_1776_test() {
-  convert(1776)
-  |> should.equal("MDCCLXXVI")
-}
-
-pub fn number_1918_test() {
-  convert(1918)
-  |> should.equal("MCMXVIII")
-}
-
-pub fn number_1954_test() {
-  convert(1954)
-  |> should.equal("MCMLIV")
-}
-
-pub fn number_2421_test() {
-  convert(2421)
-  |> should.equal("MMCDXXI")
-}
-
-pub fn number_3000_test() {
+pub fn number_3000_is_mmm_test() {
   convert(3000)
   |> should.equal("MMM")
+}
+
+pub fn number_3001_is_mmmi_test() {
+  convert(3001)
+  |> should.equal("MMMI")
+}
+
+pub fn number_3999_is_mmmcmxcix_test() {
+  convert(3999)
+  |> should.equal("MMMCMXCIX")
 }


### PR DESCRIPTION
This removes the include=false from tests.toml, as it seems like
the exclusions were probably accidental.

It then adds the missing tests, updating the test names to match
the descriptions in the canonical data.
