### PR TITLE
Tweak word-count test suite

### DIFF
--- a/exercises/practice/word-count/test/word_count_test.gleam
+++ b/exercises/practice/word-count/test/word_count_test.gleam
@@ -68,18 +68,6 @@ pub fn normalize_case_test() {
 }
 
 pub fn with_apostrophes_test() {
-  "First: don't laugh. Then: don't cry."
-  |> word_count.count_words
-  |> should.equal(map.from_list([
-    #("first", 1),
-    #("don't", 2),
-    #("laugh", 1),
-    #("then", 1),
-    #("cry", 1),
-  ]))
-}
-
-pub fn with_apostrophes_with_multiple_letters_after_test() {
   "'First: don't laugh. Then: don't cry. You're getting it.'"
   |> word_count.count_words
   |> should.equal(map.from_list([


### PR DESCRIPTION
This updates word-count to match the canonical-data.json found in
the problem-specifications repository.

This exercise has an include=false in the tests.toml, but it's
due to a test having been reimplemented in the specs.
