### PR TITLE
Swap assertion style in leap

### DIFF
--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "lpil"
   ],
+  "contributors": [
+    "kytrinyx"
+  ],
   "files": {
     "solution": [
       "src/leap.gleam"

--- a/exercises/practice/leap/test/leap_test.gleam
+++ b/exercises/practice/leap/test/leap_test.gleam
@@ -1,52 +1,42 @@
 import leap
 import gleeunit
-import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
 }
 
 pub fn year_not_divisible_by_4_in_common_year_test() {
-  leap.is_leap_year(2015)
-  |> should.be_false
+  assert False = leap.is_leap_year(2015)
 }
 
 pub fn year_divisible_by_2_not_divisible_by_4_in_common_year_test() {
-  leap.is_leap_year(1970)
-  |> should.be_false
+  assert False = leap.is_leap_year(1970)
 }
 
 pub fn year_divisible_by_4_not_divisible_by_100_in_leap_year_test() {
-  leap.is_leap_year(1996)
-  |> should.be_true
+  assert True = leap.is_leap_year(1996)
 }
 
 pub fn year_divisible_by_4_and_5_is_still_a_leap_year_test() {
-  leap.is_leap_year(1960)
-  |> should.be_true
+  assert True = leap.is_leap_year(1960)
 }
 
 pub fn year_divisible_by_100_not_divisible_by_400_in_common_year_test() {
-  leap.is_leap_year(2100)
-  |> should.be_false
+  assert False = leap.is_leap_year(2100)
 }
 
 pub fn year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year_test() {
-  leap.is_leap_year(1900)
-  |> should.be_false
+  assert False = leap.is_leap_year(1900)
 }
 
 pub fn year_divisible_by_400_is_leap_year_test() {
-  leap.is_leap_year(2000)
-  |> should.be_true
+  assert True = leap.is_leap_year(2000)
 }
 
 pub fn year_divisible_by_400_but_not_by_125_is_still_a_leap_year_test() {
-  leap.is_leap_year(2400)
-  |> should.be_true
+  assert True = leap.is_leap_year(2400)
 }
 
 pub fn year_divisible_by_200_not_divisible_by_400_in_common_year_test() {
-  leap.is_leap_year(1800)
-  |> should.be_false
+  assert False = leap.is_leap_year(1800)
 }


### PR DESCRIPTION
This switches leap to use the assert True style of
assertions rather than the should.be_true style.
