### PR TITLE
Tweak dominoes to match canonical data

### DIFF
--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "lpil",
-    "kytrinyx"
+    "kytrinyx",
+    "jiegillet"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -3,7 +3,8 @@
     "massivefermion"
   ],
   "contributors": [
-    "lpil"
+    "lpil",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/dominoes/.meta/example.gleam
+++ b/exercises/practice/dominoes/.meta/example.gleam
@@ -1,6 +1,24 @@
 import gleam/list
 import gleam/queue
 
+pub fn can_chain(chain: List(#(Int, Int))) -> Bool {
+  case chain {
+    [] -> True
+
+    [tile] -> tile.0 == tile.1
+
+    _ -> {
+      let no_solution =
+        chain
+        |> list.permutations
+        |> list.filter(check)
+        |> list.is_empty
+
+      !no_solution
+    }
+  }
+}
+
 fn check(chain: List(#(Int, Int))) -> Bool {
   let checked_chain =
     list.fold_until(
@@ -39,22 +57,5 @@ fn check(chain: List(#(Int, Int))) -> Bool {
       }
 
     False -> False
-  }
-}
-
-pub fn arrange(chain: List(#(Int, Int))) -> List(List(#(Int, Int))) {
-  case chain {
-    [] -> []
-
-    [tile] ->
-      case tile.0 == tile.1 {
-        True -> [chain]
-        False -> []
-      }
-
-    _ ->
-      chain
-      |> list.permutations
-      |> list.filter(check)
   }
 }

--- a/exercises/practice/dominoes/.meta/tests.toml
+++ b/exercises/practice/dominoes/.meta/tests.toml
@@ -23,36 +23,27 @@ description = "three elements"
 
 [99e615c6-c059-401c-9e87-ad7af11fea5c]
 description = "can reverse dominoes"
-include = false
 
 [51f0c291-5d43-40c5-b316-0429069528c9]
 description = "can't be chained"
-include = false
 
 [9a75e078-a025-4c23-8c3a-238553657f39]
 description = "disconnected - simple"
-include = false
 
 [0da0c7fe-d492-445d-b9ef-1f111f07a301]
 description = "disconnected - double loop"
-include = false
 
 [b6087ff0-f555-4ea0-a71c-f9d707c5994a]
 description = "disconnected - single isolated"
-include = false
 
 [2174fbdc-8b48-4bac-9914-8090d06ef978]
 description = "need backtrack"
-include = false
 
 [167bb480-dfd1-4318-a20d-4f90adb4a09f]
 description = "separate loops"
-include = false
 
 [cd061538-6046-45a7-ace9-6708fe8f6504]
 description = "nine elements"
-include = false
 
 [44704c7c-3adb-4d98-bd30-f45527cf8b49]
 description = "separate three-domino loops"
-include = false

--- a/exercises/practice/dominoes/src/dominoes.gleam
+++ b/exercises/practice/dominoes/src/dominoes.gleam
@@ -1,3 +1,3 @@
-pub fn arrange(chain: List(#(Int, Int))) -> List(List(#(Int, Int))) {
+pub fn can_chain(chain: List(#(Int, Int))) -> Bool {
   todo
 }

--- a/exercises/practice/dominoes/test/dominoes_test.gleam
+++ b/exercises/practice/dominoes/test/dominoes_test.gleam
@@ -1,5 +1,4 @@
 import dominoes.{can_chain}
-import gleam/list
 import gleeunit
 
 pub fn main() {

--- a/exercises/practice/dominoes/test/dominoes_test.gleam
+++ b/exercises/practice/dominoes/test/dominoes_test.gleam
@@ -7,132 +7,69 @@ pub fn main() {
   gleeunit.main()
 }
 
-pub fn empty_test() {
+pub fn empty_input_empty_output_test() {
   []
   |> arrange
   |> list.length
   |> should.equal(0)
 }
 
-pub fn impossible_one_tile_test() {
-  [#(2, 4)]
-  |> arrange
-  |> list.length
-  |> should.equal(0)
+pub fn singleton_input_singleton_output_test() {
+  assert [_, ..] = arrange([#(1, 1)])
 }
 
-pub fn another_impossible_one_tile_test() {
-  [#(5, 3)]
-  |> arrange
-  |> list.length
-  |> should.equal(0)
+pub fn singleton_that_cant_be_chained_test() {
+  assert [] = arrange([#(1, 2)])
 }
 
-pub fn impossible_two_tile_test() {
-  [#(4, 2), #(5, 3)]
-  |> arrange
-  |> list.length
-  |> should.equal(0)
+pub fn three_elements_test() {
+  assert [_, ..] = arrange([#(1, 2), #(3, 1), #(2, 3)])
 }
 
-pub fn another_impossible_two_tile_test() {
-  [#(3, 5), #(2, 4)]
-  |> arrange
-  |> list.length
-  |> should.equal(0)
+pub fn can_reverse_dominoes_test() {
+  assert [_, ..] = arrange([#(1, 2), #(1, 3), #(2, 3)])
 }
 
-pub fn impossible_three_tile_test() {
-  [#(5, 3), #(4, 2), #(2, 5)]
-  |> arrange
-  |> list.length
-  |> should.equal(0)
+pub fn cant_be_chained_test() {
+  assert [] = arrange([#(1, 2), #(4, 1), #(2, 3)])
 }
 
-pub fn another_impossible_three_tile_test() {
-  [#(5, 3), #(4, 5), #(2, 3)]
-  |> arrange
-  |> list.length
-  |> should.equal(0)
+pub fn disconnected_simple_test() {
+  assert [] = arrange([#(1, 1), #(2, 2)])
 }
 
-pub fn one_tile_test() {
-  {
-    [#(2, 2)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
+pub fn disconnected_double_loop_test() {
+  assert [] = arrange([#(1, 2), #(2, 1), #(3, 4), #(4, 3)])
 }
 
-pub fn two_tile_test() {
-  {
-    [#(2, 4), #(2, 4)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
+pub fn disconnected_single_isolated_test() {
+  assert [] = arrange([#(1, 2), #(2, 3), #(3, 1), #(4, 4)])
 }
 
-pub fn another_two_tile_test() {
-  {
-    [#(5, 0), #(5, 0)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
+pub fn need_backtrack_test() {
+  assert [_, ..] = arrange([#(1, 2), #(2, 3), #(3, 1), #(2, 4), #(2, 4)])
 }
 
-pub fn three_tile_test() {
-  {
-    [#(2, 1), #(2, 3), #(1, 3)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
+pub fn separate_loops_test() {
+  assert [_, ..] =
+    arrange([#(1, 2), #(2, 3), #(3, 1), #(1, 1), #(2, 2), #(3, 3)])
 }
 
-pub fn another_three_tile_test() {
-  {
-    [#(6, 4), #(6, 0), #(4, 0)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
+pub fn nine_elements_test() {
+  assert [_, ..] =
+    arrange([
+      #(1, 2),
+      #(5, 3),
+      #(3, 1),
+      #(1, 2),
+      #(2, 4),
+      #(1, 6),
+      #(2, 3),
+      #(3, 4),
+      #(5, 6),
+    ])
 }
 
-pub fn four_tile_test() {
-  {
-    [#(2, 1), #(2, 3), #(1, 3), #(1, 1)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
-}
-
-pub fn another_four_tile_test() {
-  {
-    [#(6, 4), #(6, 2), #(2, 0), #(4, 0)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
-}
-
-pub fn five_tile_test() {
-  {
-    [#(2, 5), #(2, 1), #(1, 0), #(0, 5), #(5, 5)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
-}
-
-pub fn another_file_tile_test() {
-  {
-    [#(4, 3), #(6, 2), #(4, 3), #(3, 6), #(2, 3)]
-    |> arrange
-    |> list.length > 0
-  }
-  |> should.be_true
+pub fn separate_three_domino_loops_test() {
+  assert [] = arrange([#(1, 2), #(2, 3), #(3, 1), #(4, 5), #(5, 6), #(6, 4)])
 }

--- a/exercises/practice/dominoes/test/dominoes_test.gleam
+++ b/exercises/practice/dominoes/test/dominoes_test.gleam
@@ -1,63 +1,59 @@
-import dominoes.{arrange}
+import dominoes.{can_chain}
 import gleam/list
 import gleeunit
-import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
 }
 
 pub fn empty_input_empty_output_test() {
-  []
-  |> arrange
-  |> list.length
-  |> should.equal(0)
+  assert True = can_chain([])
 }
 
 pub fn singleton_input_singleton_output_test() {
-  assert [_, ..] = arrange([#(1, 1)])
+  assert True = can_chain([#(1, 1)])
 }
 
 pub fn singleton_that_cant_be_chained_test() {
-  assert [] = arrange([#(1, 2)])
+  assert False = can_chain([#(1, 2)])
 }
 
 pub fn three_elements_test() {
-  assert [_, ..] = arrange([#(1, 2), #(3, 1), #(2, 3)])
+  assert True = can_chain([#(1, 2), #(3, 1), #(2, 3)])
 }
 
 pub fn can_reverse_dominoes_test() {
-  assert [_, ..] = arrange([#(1, 2), #(1, 3), #(2, 3)])
+  assert True = can_chain([#(1, 2), #(1, 3), #(2, 3)])
 }
 
 pub fn cant_be_chained_test() {
-  assert [] = arrange([#(1, 2), #(4, 1), #(2, 3)])
+  assert False = can_chain([#(1, 2), #(4, 1), #(2, 3)])
 }
 
 pub fn disconnected_simple_test() {
-  assert [] = arrange([#(1, 1), #(2, 2)])
+  assert False = can_chain([#(1, 1), #(2, 2)])
 }
 
 pub fn disconnected_double_loop_test() {
-  assert [] = arrange([#(1, 2), #(2, 1), #(3, 4), #(4, 3)])
+  assert False = can_chain([#(1, 2), #(2, 1), #(3, 4), #(4, 3)])
 }
 
 pub fn disconnected_single_isolated_test() {
-  assert [] = arrange([#(1, 2), #(2, 3), #(3, 1), #(4, 4)])
+  assert False = can_chain([#(1, 2), #(2, 3), #(3, 1), #(4, 4)])
 }
 
 pub fn need_backtrack_test() {
-  assert [_, ..] = arrange([#(1, 2), #(2, 3), #(3, 1), #(2, 4), #(2, 4)])
+  assert True = can_chain([#(1, 2), #(2, 3), #(3, 1), #(2, 4), #(2, 4)])
 }
 
 pub fn separate_loops_test() {
-  assert [_, ..] =
-    arrange([#(1, 2), #(2, 3), #(3, 1), #(1, 1), #(2, 2), #(3, 3)])
+  assert True =
+    can_chain([#(1, 2), #(2, 3), #(3, 1), #(1, 1), #(2, 2), #(3, 3)])
 }
 
 pub fn nine_elements_test() {
-  assert [_, ..] =
-    arrange([
+  assert True =
+    can_chain([
       #(1, 2),
       #(5, 3),
       #(3, 1),
@@ -71,5 +67,6 @@ pub fn nine_elements_test() {
 }
 
 pub fn separate_three_domino_loops_test() {
-  assert [] = arrange([#(1, 2), #(2, 3), #(3, 1), #(4, 5), #(5, 6), #(6, 4)])
+  assert False =
+    can_chain([#(1, 2), #(2, 3), #(3, 1), #(4, 5), #(5, 6), #(6, 4)])
 }


### PR DESCRIPTION
This deletes some include=false in the tests.toml
per #134.

It also rewords the assertions with the goal of avoiding
the should.be_true style of assertion, per #148.

Finally it normalizes the test names based on the test
descriptions in the canonical-data.json file from
problem-specifications.
