### PR TITLE
forth test cleanup

### DIFF
--- a/exercises/practice/forth/test/forth_test.gleam
+++ b/exercises/practice/forth/test/forth_test.gleam
@@ -142,7 +142,9 @@ pub fn redefining_an_existing_builtin_word_test() {
 pub fn defining_words_with_odd_characters_test() {
   forth.new()
   |> forth.eval(": € 220371 ;")
-  |> succeed_with("€")
+  |> result.then(forth.eval(_, "€"))
+  |> result.map(forth.format_stack)
+  |> succeed_with("220371")
 }
 
 pub fn defining_a_number_test() {

--- a/exercises/practice/forth/test/forth_test.gleam
+++ b/exercises/practice/forth/test/forth_test.gleam
@@ -94,21 +94,21 @@ pub fn stack_swap_fail2_test() {
   |> error_with(forth.StackUnderflow)
 }
 
-pub fn stack_over_test1() {
+pub fn stack_over_1_test() {
   run_forth_for("1 2 over", "1 2 1")
 }
 
-pub fn stack_over_test2() {
+pub fn stack_over_2_test() {
   run_forth_for("1 2 3 over", "1 2 3 2")
 }
 
-pub fn stack_over_fail_test1() {
+pub fn stack_over_fail_1_test() {
   forth.new()
   |> forth.eval("1 over")
   |> error_with(forth.StackUnderflow)
 }
 
-pub fn stack_over_fail_test2() {
+pub fn stack_over_fail_2_test() {
   forth.new()
   |> forth.eval("over")
   |> error_with(forth.StackUnderflow)
@@ -131,7 +131,7 @@ pub fn redefine_existing_word_test() {
   |> succeed_with("1 1 1")
 }
 
-pub fn redefining_an_existing_builtin_word() {
+pub fn redefining_an_existing_builtin_word_test() {
   forth.new()
   |> forth.eval(": swap dup ;")
   |> result.then(forth.eval(_, "1 swap"))
@@ -139,17 +139,19 @@ pub fn redefining_an_existing_builtin_word() {
   |> succeed_with("1 1")
 }
 
-pub fn defining_words_with_odd_characters() {
-  run_forth_for(": € 220371 ; €", "220371")
+pub fn defining_words_with_odd_characters_test() {
+  forth.new()
+  |> forth.eval(": € 220371 ;")
+  |> succeed_with("€")
 }
 
-pub fn defining_a_number() {
+pub fn defining_a_number_test() {
   forth.new()
   |> forth.eval(": 1 2 ;")
   |> error_with(forth.InvalidWord)
 }
 
-pub fn calling_a_nonexistent_word() {
+pub fn calling_a_nonexistent_word_test() {
   forth.new()
   |> forth.eval("1 foo")
   |> error_with(forth.UnknownWord)


### PR DESCRIPTION
Some of the tests weren't running because they weren't named properly (the function names have to end in _test).
I've also rewritten the test "defining_words_with_odd_characters_test" because it was the only test which
required two "statements" on the same line, but I don't think that's what it meant to test. 