### PR TITLE
Sync docs and filepaths

### DIFF
--- a/bin/generate_practice_exercise.sh
+++ b/bin/generate_practice_exercise.sh
@@ -32,11 +32,12 @@ jq --arg slug "$SLUG" --arg uuid "$UUID" \
 mv config.json.tmp config.json
 
 # Create instructions and config files
-./bin/configlet sync --update --yes --docs --filepaths --metadata --exercise "$SLUG"
+./bin/configlet sync --update --yes --docs --metadata --exercise "$SLUG"
 
 packages_prefix="https://raw.githubusercontent.com/exercism/gleam-test-runner/main/packages"
 download "$exercise_dir"/gleam.toml "$packages_prefix"/gleam.toml
 download "$exercise_dir"/manifest.toml "$packages_prefix"/manifest.toml
+./bin/configlet sync --update --yes --filepaths --exercise "$SLUG"
 
 name=$(echo $SLUG | sed 's/-/_/g' )
 sed -i -e "s/name = \".*\"/name = \"$name\"/" "$exercise_dir"/gleam.toml

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Insert and search for numbers in a binary tree.",

--- a/exercises/practice/matching-brackets/.docs/instructions.md
+++ b/exercises/practice/matching-brackets/.docs/instructions.md
@@ -1,3 +1,4 @@
 # Instructions
 
 Given a string containing brackets `[]`, braces `{}`, parentheses `()`, or any combination thereof, verify that any and all pairs are matched and nested correctly.
+The string may also contain other characters, which for the purposes of this exercise should be ignored.

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Make sure the brackets and braces all match.",

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Write a robot simulator.",

--- a/exercises/practice/satellite/.meta/config.json
+++ b/exercises/practice/satellite/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Rebuild binary trees from pre-order and in-order traversals."

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[7ae7a46a-d992-4c2a-9c15-a112d125ebad]
+description = "slices of one from one"
+
+[3143b71d-f6a5-4221-aeae-619f906244d2]
+description = "slices of one from two"
+
+[dbb68ff5-76c5-4ccd-895a-93dbec6d5805]
+description = "slices of two"
+
+[19bbea47-c987-4e11-a7d1-e103442adf86]
+description = "slices of two overlap"
+
+[8e17148d-ba0a-4007-a07f-d7f87015d84c]
+description = "slices can include duplicates"
+
+[bd5b085e-f612-4f81-97a8-6314258278b0]
+description = "slices of a long series"
+
+[6d235d85-46cf-4fae-9955-14b6efef27cd]
+description = "slice length is too large"
+
+[d7957455-346d-4e47-8e4b-87ed1564c6d7]
+description = "slice length is way too large"
+
+[d34004ad-8765-4c09-8ba1-ada8ce776806]
+description = "slice length cannot be zero"
+
+[10ab822d-8410-470a-a85d-23fbeb549e54]
+description = "slice length cannot be negative"
+
+[c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2]
+description = "empty series is invalid"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Tally the results of a small football competition."

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -11,6 +11,10 @@
     ],
     "example": [
       ".meta/example.gleam"
+    ],
+    "invalidator": [
+      "gleam.toml",
+      "manifest.toml"
     ]
   },
   "blurb": "Creating a zipper for a binary tree."


### PR DESCRIPTION
I realized there was a slight bug in the generator script, configlet didn't include the `"invalidator"` files in the config since the files in questions were not created yet.

Also a missing `tests.toml` file (all tests were implemented already).

Also an instruction improvement pushed upstream by @michallepicki :)