### PR TITLE
script: fix unbound variable error

### DIFF
--- a/bin/generate_practice_exercise.sh
+++ b/bin/generate_practice_exercise.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # If argument not provided, print usage and exit
-if [ -z "$1" ]; then
+if [ $# -ne 1 ]; then
     echo "Usage: bin/generate_practice_exercise.sh <exercise-slug>"
     exit 1
 fi


### PR DESCRIPTION
Due to the `set` call specifying the `u` modifier, unbound variables aren't allowed to be used.

However, `$1` was used to check the number of arguments, which caused the unbound variable to occur:

```shell
erik@Eriks-MacBook-Pro-2 gleam % ./bin/generate_practice_exercise.sh
./bin/generate_practice_exercise.sh: line 7: $1: unbound variable
```

Using `$#`, which contains the number of arguments, fixes this issue:

```shell
erik@Eriks-MacBook-Pro-2 gleam % ./bin/generate_practice_exercise.sh
Usage: bin/generate_practice_exercise.sh <exercise-slug>
```
