### PR TITLE
Sync manifests after adding `gleam_bitwise`

### DIFF
--- a/bin/sync-exercise-project-configs
+++ b/bin/sync-exercise-project-configs
@@ -31,8 +31,8 @@ check() {
   project="$1"
   update_config_name "$project"
 
-  if ! diff "$canonical_config" "$project"/gleam.toml && 
-    diff "$canonical_manifest" "$project"/manifest.toml
+  if ! diff "$canonical_config" "$project"/gleam.toml || 
+    ! diff "$canonical_manifest" "$project"/manifest.toml
   then
     echo "ERROR: Config files are out of sync with gleam-test-runner config" 1>&2
     echo "Run \`bin/sync-exercise-project-configs\` to correct this" 1>&2

--- a/exercises/practice/accumulate/gleam.toml
+++ b/exercises/practice/accumulate/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/accumulate/manifest.toml
+++ b/exercises/practice/accumulate/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/acronym/gleam.toml
+++ b/exercises/practice/acronym/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/acronym/manifest.toml
+++ b/exercises/practice/acronym/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/alphametics/gleam.toml
+++ b/exercises/practice/alphametics/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/alphametics/manifest.toml
+++ b/exercises/practice/alphametics/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/anagram/gleam.toml
+++ b/exercises/practice/anagram/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/anagram/manifest.toml
+++ b/exercises/practice/anagram/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/armstrong-numbers/gleam.toml
+++ b/exercises/practice/armstrong-numbers/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/armstrong-numbers/manifest.toml
+++ b/exercises/practice/armstrong-numbers/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/binary-search-tree/gleam.toml
+++ b/exercises/practice/binary-search-tree/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/binary-search-tree/manifest.toml
+++ b/exercises/practice/binary-search-tree/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/bob/gleam.toml
+++ b/exercises/practice/bob/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/bob/manifest.toml
+++ b/exercises/practice/bob/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/bottle-song/gleam.toml
+++ b/exercises/practice/bottle-song/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/bottle-song/manifest.toml
+++ b/exercises/practice/bottle-song/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/bowling/gleam.toml
+++ b/exercises/practice/bowling/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/bowling/manifest.toml
+++ b/exercises/practice/bowling/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/change/gleam.toml
+++ b/exercises/practice/change/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/change/manifest.toml
+++ b/exercises/practice/change/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/circular-buffer/gleam.toml
+++ b/exercises/practice/circular-buffer/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/circular-buffer/manifest.toml
+++ b/exercises/practice/circular-buffer/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/collatz-conjecture/gleam.toml
+++ b/exercises/practice/collatz-conjecture/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/collatz-conjecture/manifest.toml
+++ b/exercises/practice/collatz-conjecture/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/darts/gleam.toml
+++ b/exercises/practice/darts/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/darts/manifest.toml
+++ b/exercises/practice/darts/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/diamond/gleam.toml
+++ b/exercises/practice/diamond/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/diamond/manifest.toml
+++ b/exercises/practice/diamond/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/difference-of-squares/gleam.toml
+++ b/exercises/practice/difference-of-squares/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/difference-of-squares/manifest.toml
+++ b/exercises/practice/difference-of-squares/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/dominoes/gleam.toml
+++ b/exercises/practice/dominoes/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/dominoes/manifest.toml
+++ b/exercises/practice/dominoes/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/etl/gleam.toml
+++ b/exercises/practice/etl/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/etl/manifest.toml
+++ b/exercises/practice/etl/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/forth/gleam.toml
+++ b/exercises/practice/forth/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/forth/manifest.toml
+++ b/exercises/practice/forth/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/freelancer-rates/gleam.toml
+++ b/exercises/practice/freelancer-rates/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/freelancer-rates/manifest.toml
+++ b/exercises/practice/freelancer-rates/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/grains/gleam.toml
+++ b/exercises/practice/grains/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/grains/manifest.toml
+++ b/exercises/practice/grains/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/hamming/gleam.toml
+++ b/exercises/practice/hamming/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/hamming/manifest.toml
+++ b/exercises/practice/hamming/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/hello-world/gleam.toml
+++ b/exercises/practice/hello-world/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/hello-world/manifest.toml
+++ b/exercises/practice/hello-world/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/high-scores/gleam.toml
+++ b/exercises/practice/high-scores/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/high-scores/manifest.toml
+++ b/exercises/practice/high-scores/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/isogram/gleam.toml
+++ b/exercises/practice/isogram/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/isogram/manifest.toml
+++ b/exercises/practice/isogram/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/leap/gleam.toml
+++ b/exercises/practice/leap/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/leap/manifest.toml
+++ b/exercises/practice/leap/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/list-ops/gleam.toml
+++ b/exercises/practice/list-ops/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/list-ops/manifest.toml
+++ b/exercises/practice/list-ops/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/matching-brackets/gleam.toml
+++ b/exercises/practice/matching-brackets/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/matching-brackets/manifest.toml
+++ b/exercises/practice/matching-brackets/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/nucleotide-count/gleam.toml
+++ b/exercises/practice/nucleotide-count/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/nucleotide-count/manifest.toml
+++ b/exercises/practice/nucleotide-count/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pangram/gleam.toml
+++ b/exercises/practice/pangram/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/pangram/manifest.toml
+++ b/exercises/practice/pangram/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pascals-triangle/gleam.toml
+++ b/exercises/practice/pascals-triangle/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/pascals-triangle/manifest.toml
+++ b/exercises/practice/pascals-triangle/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/perfect-numbers/gleam.toml
+++ b/exercises/practice/perfect-numbers/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/perfect-numbers/manifest.toml
+++ b/exercises/practice/perfect-numbers/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/phone-number/gleam.toml
+++ b/exercises/practice/phone-number/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/phone-number/manifest.toml
+++ b/exercises/practice/phone-number/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/prime-factors/gleam.toml
+++ b/exercises/practice/prime-factors/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/prime-factors/manifest.toml
+++ b/exercises/practice/prime-factors/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/protein-translation/gleam.toml
+++ b/exercises/practice/protein-translation/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/protein-translation/manifest.toml
+++ b/exercises/practice/protein-translation/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/proverb/gleam.toml
+++ b/exercises/practice/proverb/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/proverb/manifest.toml
+++ b/exercises/practice/proverb/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pythagorean-triplet/gleam.toml
+++ b/exercises/practice/pythagorean-triplet/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/pythagorean-triplet/manifest.toml
+++ b/exercises/practice/pythagorean-triplet/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/raindrops/gleam.toml
+++ b/exercises/practice/raindrops/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/raindrops/manifest.toml
+++ b/exercises/practice/raindrops/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/rectangles/gleam.toml
+++ b/exercises/practice/rectangles/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/rectangles/manifest.toml
+++ b/exercises/practice/rectangles/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/resistor-color-trio/gleam.toml
+++ b/exercises/practice/resistor-color-trio/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/resistor-color-trio/manifest.toml
+++ b/exercises/practice/resistor-color-trio/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/resistor-color/gleam.toml
+++ b/exercises/practice/resistor-color/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/resistor-color/manifest.toml
+++ b/exercises/practice/resistor-color/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/reverse-string/gleam.toml
+++ b/exercises/practice/reverse-string/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/reverse-string/manifest.toml
+++ b/exercises/practice/reverse-string/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/rna-transcription/gleam.toml
+++ b/exercises/practice/rna-transcription/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/rna-transcription/manifest.toml
+++ b/exercises/practice/rna-transcription/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/robot-simulator/gleam.toml
+++ b/exercises/practice/robot-simulator/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/robot-simulator/manifest.toml
+++ b/exercises/practice/robot-simulator/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/roman-numerals/gleam.toml
+++ b/exercises/practice/roman-numerals/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/roman-numerals/manifest.toml
+++ b/exercises/practice/roman-numerals/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/rotational-cipher/gleam.toml
+++ b/exercises/practice/rotational-cipher/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/rotational-cipher/manifest.toml
+++ b/exercises/practice/rotational-cipher/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/run-length-encoding/gleam.toml
+++ b/exercises/practice/run-length-encoding/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/run-length-encoding/manifest.toml
+++ b/exercises/practice/run-length-encoding/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/satellite/gleam.toml
+++ b/exercises/practice/satellite/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/satellite/manifest.toml
+++ b/exercises/practice/satellite/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/scrabble-score/gleam.toml
+++ b/exercises/practice/scrabble-score/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/scrabble-score/manifest.toml
+++ b/exercises/practice/scrabble-score/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/series/gleam.toml
+++ b/exercises/practice/series/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/series/manifest.toml
+++ b/exercises/practice/series/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/sum-of-multiples/gleam.toml
+++ b/exercises/practice/sum-of-multiples/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/sum-of-multiples/manifest.toml
+++ b/exercises/practice/sum-of-multiples/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/tournament/gleam.toml
+++ b/exercises/practice/tournament/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/tournament/manifest.toml
+++ b/exercises/practice/tournament/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/two-fer/gleam.toml
+++ b/exercises/practice/two-fer/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/two-fer/manifest.toml
+++ b/exercises/practice/two-fer/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/word-count/gleam.toml
+++ b/exercises/practice/word-count/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/word-count/manifest.toml
+++ b/exercises/practice/word-count/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"

--- a/exercises/practice/zipper/gleam.toml
+++ b/exercises/practice/zipper/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.26"
+gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/exercises/practice/zipper/manifest.toml
+++ b/exercises/practice/zipper/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
   { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
+gleam_bitwise = "~> 1.2"
 gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.10"


### PR DESCRIPTION
I was a bit surprised to not see any CI failures, turns out there was a bug in the logic.
This commit is supposed to fail the CI, because there are unsynced manifests in the repo.
I will fix them later, then the CI should pass.