### PR TITLE
Proposal: alternative way to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin/configlet
 bin/configlet.exe
 exercises/practice/*/build
+all_exercises

--- a/bin/test
+++ b/bin/test
@@ -74,7 +74,7 @@ function copy_exercise {
 }
 
 function run_all {
-  # create a all_exercises folder
+  # create an all_exercises folder
   mkdir -p all_exercises all_exercises/src all_exercises/test
 
   cat <<EOT > all_exercises/test/all_exercises_test.gleam
@@ -111,7 +111,7 @@ EOT
   done
 
   # Running all tests
-    if ! (cd all_exercises && gleam test)
+  if ! (cd all_exercises && gleam test)
   then
     echo "A solution did not pass the tests"
     exit_code=1

--- a/bin/test
+++ b/bin/test
@@ -44,26 +44,80 @@ function verify_exercise {
   mv "${stub_backup_file}" "${stub_file}"
 }
 
+download() {
+  file="$1"
+  url="$2"
+  curl --silent --show-error --fail --retry 3 --max-time 3 \
+    --output "$file" "$url"
+}
+
+function copy_exercise {
+  local dir slug implementation_file stub_backup_file module
+  dir="$1"
+  dest="$2"
+  slug=$(basename "${dir}")
+  module=${slug//-/_}
+
+  implementation_destination="${dest}/src/${module}.gleam"
+  practice_solution="${dir}/.meta/example.gleam"
+  if [ -f "${practice_solution}" ]
+   then cp "${practice_solution}" "${implementation_destination}"
+  fi
+  concept_solution="${dir}/.meta/src/${module}.gleam"
+  if [ -f "${concept_solution}" ]
+   then cp "${concept_solution}" "${implementation_destination}"
+  fi
+
+  test_file="${dir}/test/${module}_test.gleam"
+  test_destination="${dest}/test/${module}_test.gleam"
+  cp "${test_file}" "${test_destination}"
+}
+
 function run_all {
-  # Verify the Concept Exercises
+  # create a all_exercises folder
+  mkdir -p all_exercises all_exercises/src all_exercises/test
+
+  cat <<EOT > all_exercises/test/all_exercises_test.gleam
+import gleeunit
+
+pub fn main() {
+  gleeunit.main()
+}
+EOT
+
+  packages_prefix="https://raw.githubusercontent.com/exercism/gleam-test-runner/main/packages"
+  download all_exercises/gleam.toml "$packages_prefix"/gleam.toml
+  download all_exercises/manifest.toml "$packages_prefix"/manifest.toml
+  sed -i -e "s/name = \".*\"/name = \"all_exercises\"/" all_exercises/gleam.toml
+
+  # Copy the Concept Exercises
   for concept_exercise_dir in ./exercises/concept/*/
   do
     if [ -d "$concept_exercise_dir" ]
     then
-      echo "Checking $(basename "${concept_exercise_dir}") concept exercise..."
-      verify_exercise "${concept_exercise_dir}"
+      echo "Copying $(basename "${concept_exercise_dir}") concept exercise..."
+      copy_exercise "${concept_exercise_dir}" all_exercises
     fi
   done
 
-  # Verify the Practice Exercises
+  # Copy the Practice Exercises
   for practice_exercise_dir in ./exercises/practice/*/
   do
     if [ -d "$practice_exercise_dir" ]
     then
-      echo "Checking $(basename "${practice_exercise_dir}") practice exercise..."
-      verify_exercise "${practice_exercise_dir}"
+      echo "Copying $(basename "${practice_exercise_dir}") practice exercise..."
+      copy_exercise "${practice_exercise_dir}" all_exercises
     fi
   done
+
+  # Running all tests
+    if ! (cd all_exercises && gleam test)
+  then
+    echo "A solution did not pass the tests"
+    exit_code=1
+  fi
+
+  rm -r all_exercises
 }
 
 case $# in


### PR DESCRIPTION
I got a little bit impatient looking at the tests run, so I though I would propose this alternate approach that we use on the Elm track of copying all solutions and tests into one big project and run that.

This takes the process a bit further away from what the students would experience, so I understand if you want to turn this down.

This version runs in 14s, as opposed to almost 4 minutes for the current version on my machine.

The output in case of an error is decent:

```
➜  gleam git:(main) ✗ bin/test
Copying accumulate practice exercise...
Copying [...many more...]
Copying zipper practice exercise...
  Compiling all_exercises
   Compiled in 1.83s
    Running all_exercises_test.main
.....F..................................................................................................................................................................................
.........................................................................................................................................................................................
.........................................................................................................................................................................................
...................................................................................................................................................................
Failures:

  1) acronym_test.basic_test
     Values were not equal
     expected: "PNG - I tweaked this test"
          got: "PNG"
     output: 

Finished in 9.310 seconds
717 tests, 1 failures
A solution did not pass the tests
```