### PR TITLE
roman-numerals: specify return type

### DIFF
--- a/exercises/practice/roman-numerals/.meta/example.gleam
+++ b/exercises/practice/roman-numerals/.meta/example.gleam
@@ -1,7 +1,7 @@
 import gleam/list
 import gleam/string
 
-pub fn convert(number: Int) {
+pub fn convert(number: Int) -> String {
   number
   |> list.repeat("I", _)
   |> string.concat

--- a/exercises/practice/roman-numerals/src/roman_numerals.gleam
+++ b/exercises/practice/roman-numerals/src/roman_numerals.gleam
@@ -1,3 +1,3 @@
-pub fn convert(number: Int) {
+pub fn convert(number: Int) -> String {
   todo
 }


### PR DESCRIPTION
Not sure if this (not defining the return type) was intentional or not.