### PR TITLE
Bump Gleam stdlib to 0.27

### DIFF
--- a/exercise_generator/gleam.toml
+++ b/exercise_generator/gleam.toml
@@ -3,7 +3,7 @@ version = "0.1.0"
 description = "Test and stub file generator for the Exercism Gleam track"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_erlang = "~> 0.17"
 gleam_json = "~> 0.5"
 

--- a/exercise_generator/manifest.toml
+++ b/exercise_generator/manifest.toml
@@ -11,4 +11,4 @@ packages = [
 [requirements]
 gleam_erlang = "~> 0.17"
 gleam_json = "~> 0.5"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"

--- a/exercises/practice/accumulate/gleam.toml
+++ b/exercises/practice/accumulate/gleam.toml
@@ -2,7 +2,7 @@ name = "accumulate"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/accumulate/manifest.toml
+++ b/exercises/practice/accumulate/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/acronym/gleam.toml
+++ b/exercises/practice/acronym/gleam.toml
@@ -2,7 +2,7 @@ name = "acronym"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/acronym/manifest.toml
+++ b/exercises/practice/acronym/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/affine-cipher/gleam.toml
+++ b/exercises/practice/affine-cipher/gleam.toml
@@ -2,7 +2,7 @@ name = "affine_cipher"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/affine-cipher/manifest.toml
+++ b/exercises/practice/affine-cipher/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/all-your-base/gleam.toml
+++ b/exercises/practice/all-your-base/gleam.toml
@@ -2,7 +2,7 @@ name = "all_your_base"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/all-your-base/manifest.toml
+++ b/exercises/practice/all-your-base/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/allergies/gleam.toml
+++ b/exercises/practice/allergies/gleam.toml
@@ -2,7 +2,7 @@ name = "allergies"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/allergies/manifest.toml
+++ b/exercises/practice/allergies/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/alphametics/gleam.toml
+++ b/exercises/practice/alphametics/gleam.toml
@@ -2,7 +2,7 @@ name = "alphametics"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/alphametics/manifest.toml
+++ b/exercises/practice/alphametics/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/anagram/gleam.toml
+++ b/exercises/practice/anagram/gleam.toml
@@ -2,7 +2,7 @@ name = "anagram"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/anagram/manifest.toml
+++ b/exercises/practice/anagram/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/armstrong-numbers/gleam.toml
+++ b/exercises/practice/armstrong-numbers/gleam.toml
@@ -2,7 +2,7 @@ name = "armstrong_numbers"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/armstrong-numbers/manifest.toml
+++ b/exercises/practice/armstrong-numbers/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/atbash-cipher/gleam.toml
+++ b/exercises/practice/atbash-cipher/gleam.toml
@@ -2,7 +2,7 @@ name = "atbash_cipher"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/atbash-cipher/manifest.toml
+++ b/exercises/practice/atbash-cipher/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/binary-search-tree/gleam.toml
+++ b/exercises/practice/binary-search-tree/gleam.toml
@@ -2,7 +2,7 @@ name = "binary_search_tree"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/binary-search-tree/manifest.toml
+++ b/exercises/practice/binary-search-tree/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/bob/gleam.toml
+++ b/exercises/practice/bob/gleam.toml
@@ -2,7 +2,7 @@ name = "bob"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/bob/manifest.toml
+++ b/exercises/practice/bob/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/bottle-song/gleam.toml
+++ b/exercises/practice/bottle-song/gleam.toml
@@ -2,7 +2,7 @@ name = "bottle_song"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/bottle-song/manifest.toml
+++ b/exercises/practice/bottle-song/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/bowling/gleam.toml
+++ b/exercises/practice/bowling/gleam.toml
@@ -2,7 +2,7 @@ name = "bowling"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/bowling/manifest.toml
+++ b/exercises/practice/bowling/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/change/gleam.toml
+++ b/exercises/practice/change/gleam.toml
@@ -2,7 +2,7 @@ name = "change"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/change/manifest.toml
+++ b/exercises/practice/change/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/circular-buffer/gleam.toml
+++ b/exercises/practice/circular-buffer/gleam.toml
@@ -2,7 +2,7 @@ name = "circular_buffer"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/circular-buffer/manifest.toml
+++ b/exercises/practice/circular-buffer/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/clock/gleam.toml
+++ b/exercises/practice/clock/gleam.toml
@@ -2,7 +2,7 @@ name = "clock"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/clock/manifest.toml
+++ b/exercises/practice/clock/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/collatz-conjecture/gleam.toml
+++ b/exercises/practice/collatz-conjecture/gleam.toml
@@ -2,7 +2,7 @@ name = "collatz_conjecture"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/collatz-conjecture/manifest.toml
+++ b/exercises/practice/collatz-conjecture/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/connect/gleam.toml
+++ b/exercises/practice/connect/gleam.toml
@@ -2,7 +2,7 @@ name = "connect"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/connect/manifest.toml
+++ b/exercises/practice/connect/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/crypto-square/gleam.toml
+++ b/exercises/practice/crypto-square/gleam.toml
@@ -2,7 +2,7 @@ name = "crypto_square"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/crypto-square/manifest.toml
+++ b/exercises/practice/crypto-square/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/darts/gleam.toml
+++ b/exercises/practice/darts/gleam.toml
@@ -2,7 +2,7 @@ name = "darts"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/darts/manifest.toml
+++ b/exercises/practice/darts/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/diamond/gleam.toml
+++ b/exercises/practice/diamond/gleam.toml
@@ -2,7 +2,7 @@ name = "diamond"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/diamond/manifest.toml
+++ b/exercises/practice/diamond/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/difference-of-squares/gleam.toml
+++ b/exercises/practice/difference-of-squares/gleam.toml
@@ -2,7 +2,7 @@ name = "difference_of_squares"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/difference-of-squares/manifest.toml
+++ b/exercises/practice/difference-of-squares/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/dnd-character/gleam.toml
+++ b/exercises/practice/dnd-character/gleam.toml
@@ -2,7 +2,7 @@ name = "dnd_character"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/dnd-character/manifest.toml
+++ b/exercises/practice/dnd-character/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/dominoes/gleam.toml
+++ b/exercises/practice/dominoes/gleam.toml
@@ -2,7 +2,7 @@ name = "dominoes"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/dominoes/manifest.toml
+++ b/exercises/practice/dominoes/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/etl/gleam.toml
+++ b/exercises/practice/etl/gleam.toml
@@ -2,7 +2,7 @@ name = "etl"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/etl/manifest.toml
+++ b/exercises/practice/etl/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/flatten-array/gleam.toml
+++ b/exercises/practice/flatten-array/gleam.toml
@@ -2,7 +2,7 @@ name = "flatten_array"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/flatten-array/manifest.toml
+++ b/exercises/practice/flatten-array/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/forth/gleam.toml
+++ b/exercises/practice/forth/gleam.toml
@@ -2,7 +2,7 @@ name = "forth"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/forth/manifest.toml
+++ b/exercises/practice/forth/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/freelancer-rates/gleam.toml
+++ b/exercises/practice/freelancer-rates/gleam.toml
@@ -2,7 +2,7 @@ name = "freelancer_rates"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/freelancer-rates/manifest.toml
+++ b/exercises/practice/freelancer-rates/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/grade-school/gleam.toml
+++ b/exercises/practice/grade-school/gleam.toml
@@ -2,7 +2,7 @@ name = "grade_school"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/grade-school/manifest.toml
+++ b/exercises/practice/grade-school/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/grains/gleam.toml
+++ b/exercises/practice/grains/gleam.toml
@@ -2,7 +2,7 @@ name = "grains"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/grains/manifest.toml
+++ b/exercises/practice/grains/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/hamming/gleam.toml
+++ b/exercises/practice/hamming/gleam.toml
@@ -2,7 +2,7 @@ name = "hamming"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/hamming/manifest.toml
+++ b/exercises/practice/hamming/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/hello-world/gleam.toml
+++ b/exercises/practice/hello-world/gleam.toml
@@ -2,7 +2,7 @@ name = "hello_world"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/hello-world/manifest.toml
+++ b/exercises/practice/hello-world/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/high-scores/gleam.toml
+++ b/exercises/practice/high-scores/gleam.toml
@@ -2,7 +2,7 @@ name = "high_scores"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/high-scores/manifest.toml
+++ b/exercises/practice/high-scores/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/house/gleam.toml
+++ b/exercises/practice/house/gleam.toml
@@ -2,7 +2,7 @@ name = "house"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/house/manifest.toml
+++ b/exercises/practice/house/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/isbn-verifier/gleam.toml
+++ b/exercises/practice/isbn-verifier/gleam.toml
@@ -2,7 +2,7 @@ name = "isbn_verifier"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/isbn-verifier/manifest.toml
+++ b/exercises/practice/isbn-verifier/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/isogram/gleam.toml
+++ b/exercises/practice/isogram/gleam.toml
@@ -2,7 +2,7 @@ name = "isogram"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/isogram/manifest.toml
+++ b/exercises/practice/isogram/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/killer-sudoku-helper/gleam.toml
+++ b/exercises/practice/killer-sudoku-helper/gleam.toml
@@ -2,7 +2,7 @@ name = "killer_sudoku_helper"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/killer-sudoku-helper/manifest.toml
+++ b/exercises/practice/killer-sudoku-helper/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/kindergarten-garden/gleam.toml
+++ b/exercises/practice/kindergarten-garden/gleam.toml
@@ -2,7 +2,7 @@ name = "kindergarten_garden"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/kindergarten-garden/manifest.toml
+++ b/exercises/practice/kindergarten-garden/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/knapsack/gleam.toml
+++ b/exercises/practice/knapsack/gleam.toml
@@ -2,7 +2,7 @@ name = "knapsack"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/knapsack/manifest.toml
+++ b/exercises/practice/knapsack/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/largest-series-product/gleam.toml
+++ b/exercises/practice/largest-series-product/gleam.toml
@@ -2,7 +2,7 @@ name = "largest_series_product"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/largest-series-product/manifest.toml
+++ b/exercises/practice/largest-series-product/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/leap/gleam.toml
+++ b/exercises/practice/leap/gleam.toml
@@ -2,7 +2,7 @@ name = "leap"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/leap/manifest.toml
+++ b/exercises/practice/leap/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/list-ops/gleam.toml
+++ b/exercises/practice/list-ops/gleam.toml
@@ -2,7 +2,7 @@ name = "list_ops"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/list-ops/manifest.toml
+++ b/exercises/practice/list-ops/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/luhn/gleam.toml
+++ b/exercises/practice/luhn/gleam.toml
@@ -2,7 +2,7 @@ name = "luhn"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/luhn/manifest.toml
+++ b/exercises/practice/luhn/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/matching-brackets/gleam.toml
+++ b/exercises/practice/matching-brackets/gleam.toml
@@ -2,7 +2,7 @@ name = "matching_brackets"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/matching-brackets/manifest.toml
+++ b/exercises/practice/matching-brackets/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/minesweeper/gleam.toml
+++ b/exercises/practice/minesweeper/gleam.toml
@@ -2,7 +2,7 @@ name = "minesweeper"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/minesweeper/manifest.toml
+++ b/exercises/practice/minesweeper/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/nth-prime/gleam.toml
+++ b/exercises/practice/nth-prime/gleam.toml
@@ -2,7 +2,7 @@ name = "nth_prime"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/nth-prime/manifest.toml
+++ b/exercises/practice/nth-prime/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/nucleotide-count/gleam.toml
+++ b/exercises/practice/nucleotide-count/gleam.toml
@@ -2,7 +2,7 @@ name = "nucleotide_count"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/nucleotide-count/manifest.toml
+++ b/exercises/practice/nucleotide-count/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/ocr-numbers/gleam.toml
+++ b/exercises/practice/ocr-numbers/gleam.toml
@@ -2,7 +2,7 @@ name = "ocr_numbers"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/ocr-numbers/manifest.toml
+++ b/exercises/practice/ocr-numbers/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pangram/gleam.toml
+++ b/exercises/practice/pangram/gleam.toml
@@ -2,7 +2,7 @@ name = "pangram"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/pangram/manifest.toml
+++ b/exercises/practice/pangram/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pascals-triangle/gleam.toml
+++ b/exercises/practice/pascals-triangle/gleam.toml
@@ -2,7 +2,7 @@ name = "pascals_triangle"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/pascals-triangle/manifest.toml
+++ b/exercises/practice/pascals-triangle/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/perfect-numbers/gleam.toml
+++ b/exercises/practice/perfect-numbers/gleam.toml
@@ -2,7 +2,7 @@ name = "perfect_numbers"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/perfect-numbers/manifest.toml
+++ b/exercises/practice/perfect-numbers/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/phone-number/gleam.toml
+++ b/exercises/practice/phone-number/gleam.toml
@@ -2,7 +2,7 @@ name = "phone_number"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/phone-number/manifest.toml
+++ b/exercises/practice/phone-number/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pig-latin/gleam.toml
+++ b/exercises/practice/pig-latin/gleam.toml
@@ -2,7 +2,7 @@ name = "pig_latin"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/pig-latin/manifest.toml
+++ b/exercises/practice/pig-latin/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pov/gleam.toml
+++ b/exercises/practice/pov/gleam.toml
@@ -2,7 +2,7 @@ name = "pov"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/pov/manifest.toml
+++ b/exercises/practice/pov/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/prime-factors/gleam.toml
+++ b/exercises/practice/prime-factors/gleam.toml
@@ -2,7 +2,7 @@ name = "prime_factors"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/prime-factors/manifest.toml
+++ b/exercises/practice/prime-factors/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/protein-translation/gleam.toml
+++ b/exercises/practice/protein-translation/gleam.toml
@@ -2,7 +2,7 @@ name = "protein_translation"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/protein-translation/manifest.toml
+++ b/exercises/practice/protein-translation/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/proverb/gleam.toml
+++ b/exercises/practice/proverb/gleam.toml
@@ -2,7 +2,7 @@ name = "proverb"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/proverb/manifest.toml
+++ b/exercises/practice/proverb/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/pythagorean-triplet/gleam.toml
+++ b/exercises/practice/pythagorean-triplet/gleam.toml
@@ -2,7 +2,7 @@ name = "pythagorean_triplet"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/pythagorean-triplet/manifest.toml
+++ b/exercises/practice/pythagorean-triplet/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/queen-attack/gleam.toml
+++ b/exercises/practice/queen-attack/gleam.toml
@@ -2,7 +2,7 @@ name = "queen_attack"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/queen-attack/manifest.toml
+++ b/exercises/practice/queen-attack/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/raindrops/gleam.toml
+++ b/exercises/practice/raindrops/gleam.toml
@@ -2,7 +2,7 @@ name = "raindrops"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/raindrops/manifest.toml
+++ b/exercises/practice/raindrops/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/rectangles/gleam.toml
+++ b/exercises/practice/rectangles/gleam.toml
@@ -2,7 +2,7 @@ name = "rectangles"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/rectangles/manifest.toml
+++ b/exercises/practice/rectangles/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/resistor-color-duo/gleam.toml
+++ b/exercises/practice/resistor-color-duo/gleam.toml
@@ -2,7 +2,7 @@ name = "resistor_color_duo"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/resistor-color-duo/manifest.toml
+++ b/exercises/practice/resistor-color-duo/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/resistor-color-trio/gleam.toml
+++ b/exercises/practice/resistor-color-trio/gleam.toml
@@ -2,7 +2,7 @@ name = "resistor_color_trio"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/resistor-color-trio/manifest.toml
+++ b/exercises/practice/resistor-color-trio/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/resistor-color/gleam.toml
+++ b/exercises/practice/resistor-color/gleam.toml
@@ -2,7 +2,7 @@ name = "resistor_color"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/resistor-color/manifest.toml
+++ b/exercises/practice/resistor-color/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/reverse-string/gleam.toml
+++ b/exercises/practice/reverse-string/gleam.toml
@@ -2,7 +2,7 @@ name = "reverse_string"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/reverse-string/manifest.toml
+++ b/exercises/practice/reverse-string/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/rna-transcription/gleam.toml
+++ b/exercises/practice/rna-transcription/gleam.toml
@@ -2,7 +2,7 @@ name = "rna_transcription"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/rna-transcription/manifest.toml
+++ b/exercises/practice/rna-transcription/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/robot-simulator/gleam.toml
+++ b/exercises/practice/robot-simulator/gleam.toml
@@ -2,7 +2,7 @@ name = "robot_simulator"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/robot-simulator/manifest.toml
+++ b/exercises/practice/robot-simulator/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/roman-numerals/gleam.toml
+++ b/exercises/practice/roman-numerals/gleam.toml
@@ -2,7 +2,7 @@ name = "roman_numerals"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/roman-numerals/manifest.toml
+++ b/exercises/practice/roman-numerals/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/rotational-cipher/gleam.toml
+++ b/exercises/practice/rotational-cipher/gleam.toml
@@ -2,7 +2,7 @@ name = "rotational_cipher"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/rotational-cipher/manifest.toml
+++ b/exercises/practice/rotational-cipher/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/run-length-encoding/gleam.toml
+++ b/exercises/practice/run-length-encoding/gleam.toml
@@ -2,7 +2,7 @@ name = "run_length_encoding"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/run-length-encoding/manifest.toml
+++ b/exercises/practice/run-length-encoding/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/saddle-points/gleam.toml
+++ b/exercises/practice/saddle-points/gleam.toml
@@ -2,7 +2,7 @@ name = "saddle_points"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/saddle-points/manifest.toml
+++ b/exercises/practice/saddle-points/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/satellite/gleam.toml
+++ b/exercises/practice/satellite/gleam.toml
@@ -2,7 +2,7 @@ name = "satellite"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/satellite/manifest.toml
+++ b/exercises/practice/satellite/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/say/gleam.toml
+++ b/exercises/practice/say/gleam.toml
@@ -2,7 +2,7 @@ name = "say"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/say/manifest.toml
+++ b/exercises/practice/say/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/scrabble-score/gleam.toml
+++ b/exercises/practice/scrabble-score/gleam.toml
@@ -2,7 +2,7 @@ name = "scrabble_score"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/scrabble-score/manifest.toml
+++ b/exercises/practice/scrabble-score/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/secret-handshake/gleam.toml
+++ b/exercises/practice/secret-handshake/gleam.toml
@@ -2,7 +2,7 @@ name = "secret_handshake"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/secret-handshake/manifest.toml
+++ b/exercises/practice/secret-handshake/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/series/gleam.toml
+++ b/exercises/practice/series/gleam.toml
@@ -2,7 +2,7 @@ name = "series"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/series/manifest.toml
+++ b/exercises/practice/series/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/simple-cipher/gleam.toml
+++ b/exercises/practice/simple-cipher/gleam.toml
@@ -2,7 +2,7 @@ name = "simple_cipher"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/simple-cipher/manifest.toml
+++ b/exercises/practice/simple-cipher/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/space-age/gleam.toml
+++ b/exercises/practice/space-age/gleam.toml
@@ -2,7 +2,7 @@ name = "space_age"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/space-age/manifest.toml
+++ b/exercises/practice/space-age/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/square-root/gleam.toml
+++ b/exercises/practice/square-root/gleam.toml
@@ -2,7 +2,7 @@ name = "square_root"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/square-root/manifest.toml
+++ b/exercises/practice/square-root/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/sublist/gleam.toml
+++ b/exercises/practice/sublist/gleam.toml
@@ -2,7 +2,7 @@ name = "sublist"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/sublist/manifest.toml
+++ b/exercises/practice/sublist/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/sum-of-multiples/gleam.toml
+++ b/exercises/practice/sum-of-multiples/gleam.toml
@@ -2,7 +2,7 @@ name = "sum_of_multiples"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/sum-of-multiples/manifest.toml
+++ b/exercises/practice/sum-of-multiples/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/tournament/gleam.toml
+++ b/exercises/practice/tournament/gleam.toml
@@ -2,7 +2,7 @@ name = "tournament"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/tournament/manifest.toml
+++ b/exercises/practice/tournament/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/triangle/gleam.toml
+++ b/exercises/practice/triangle/gleam.toml
@@ -2,7 +2,7 @@ name = "triangle"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/triangle/manifest.toml
+++ b/exercises/practice/triangle/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/twelve-days/gleam.toml
+++ b/exercises/practice/twelve-days/gleam.toml
@@ -2,7 +2,7 @@ name = "twelve_days"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/twelve-days/manifest.toml
+++ b/exercises/practice/twelve-days/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/two-fer/gleam.toml
+++ b/exercises/practice/two-fer/gleam.toml
@@ -2,7 +2,7 @@ name = "two_fer"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/two-fer/manifest.toml
+++ b/exercises/practice/two-fer/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/variable-length-quantity/gleam.toml
+++ b/exercises/practice/variable-length-quantity/gleam.toml
@@ -2,7 +2,7 @@ name = "variable_length_quantity"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/variable-length-quantity/manifest.toml
+++ b/exercises/practice/variable-length-quantity/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/word-count/gleam.toml
+++ b/exercises/practice/word-count/gleam.toml
@@ -2,7 +2,7 @@ name = "word_count"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/word-count/manifest.toml
+++ b/exercises/practice/word-count/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/wordy/gleam.toml
+++ b/exercises/practice/wordy/gleam.toml
@@ -2,7 +2,7 @@ name = "wordy"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/wordy/manifest.toml
+++ b/exercises/practice/wordy/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/yacht/gleam.toml
+++ b/exercises/practice/yacht/gleam.toml
@@ -2,7 +2,7 @@ name = "yacht"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/yacht/manifest.toml
+++ b/exercises/practice/yacht/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"

--- a/exercises/practice/zipper/gleam.toml
+++ b/exercises/practice/zipper/gleam.toml
@@ -2,7 +2,7 @@ name = "zipper"
 version = "0.1.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_bitwise = "~> 1.2"
 
 [dev-dependencies]

--- a/exercises/practice/zipper/manifest.toml
+++ b/exercises/practice/zipper/manifest.toml
@@ -9,5 +9,5 @@ packages = [
 
 [requirements]
 gleam_bitwise = "~> 1.2"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.10"


### PR DESCRIPTION
I saw that you bumped the Gleam version in CI but didn't bump the stdlib. I tried out locally if this would break any tests and it looks fine.