### PR TITLE
Sync tests

### DIFF
--- a/exercises/practice/accumulate/.meta/tests.toml
+++ b/exercises/practice/accumulate/.meta/tests.toml
@@ -24,6 +24,7 @@ description = "accumulate reversed strings"
 [bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb]
 description = "accumulate recursively"
 include = false
+comment = "not included because reimplemented by 0b357334-4cad-49e1-a741-425202edfc7c"
 
 [0b357334-4cad-49e1-a741-425202edfc7c]
 description = "accumulate recursively"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -15,6 +15,7 @@ description = "no matches"
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
 include = false
+comment = "not included because reimplemented by 03eb9bbe-8906-4ea0-84fa-ffe711b52c8b"
 
 [03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
 description = "detects two anagrams"
@@ -53,6 +54,7 @@ description = "anagrams must use all letters exactly once"
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
 include = false
+comment = "not included because reimplemented by 68934ed0-010b-4ef9-857a-20c9012d1ebf"
 
 [68934ed0-010b-4ef9-857a-20c9012d1ebf]
 description = "words are not anagrams of themselves"
@@ -69,6 +71,7 @@ reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
 include = false
+comment = "not included because reimplemented by 33d3f67e-fbb9-49d3-a90e-0beb00861da7"
 
 [33d3f67e-fbb9-49d3-a90e-0beb00861da7]
 description = "words other than themselves can be anagrams"

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -47,7 +47,6 @@ description = "strikes with the two roll bonus do not get bonus rolls"
 
 [efb426ec-7e15-42e6-9b96-b4fca3ec2359]
 description = "last two strikes followed by only last bonus with non strike points"
-include = false
 
 [72e24404-b6c6-46af-b188-875514c0377b]
 description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"

--- a/exercises/practice/bowling/test/bowling_test.gleam
+++ b/exercises/practice/bowling/test/bowling_test.gleam
@@ -219,7 +219,7 @@ pub fn rolling_after_bonus_rolls_after_strike_test() {
   |> roll_and_last_roll_be_error(2, GameComplete)
 }
 
-pub fn last_two_strikes_followed_by_only_last_bonus_non_strike_points() {
+pub fn last_two_strikes_followed_by_only_last_bonus_non_strike_points_test() {
   let rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 0, 1]
 
   rolls

--- a/exercises/practice/bowling/test/bowling_test.gleam
+++ b/exercises/practice/bowling/test/bowling_test.gleam
@@ -219,6 +219,13 @@ pub fn rolling_after_bonus_rolls_after_strike_test() {
   |> roll_and_last_roll_be_error(2, GameComplete)
 }
 
+pub fn last_two_strikes_followed_by_only_last_bonus_non_strike_points() {
+  let rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 0, 1]
+
+  rolls
+  |> roll_and_check_score(31)
+}
+
 fn roll_and_check_score(rolls: List(Int), correct_score: Int) {
   rolls
   |> list.fold(

--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -105,6 +105,9 @@ description = "Subtract minutes -> subtract more than an hour"
 [8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6]
 description = "Subtract minutes -> subtract across midnight"
 
+[07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9]
+description = "Subtract minutes -> subtract more than two hours"
+
 [90ac8a1b-761c-4342-9c9c-cdc3ed5db097]
 description = "Subtract minutes -> subtract more than two hours with borrow"
 

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -24,6 +24,7 @@ description = "large number of even and odd steps"
 [7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
 description = "zero is an error"
 include = false
+comment = "not included because reimplemented by 2187673d-77d6-4543-975e-66df6c50e2da"
 
 [2187673d-77d6-4543-975e-66df6c50e2da]
 description = "zero is an error"
@@ -32,6 +33,7 @@ reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
 include = false
+comment = "not included because reimplemented by ec11f479-56bc-47fd-a434-bcd7a31a7a2e"
 
 [ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
 description = "negative value is an error"

--- a/exercises/practice/dnd-character/.meta/tests.toml
+++ b/exercises/practice/dnd-character/.meta/tests.toml
@@ -66,3 +66,4 @@ description = "random character is valid"
 [2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe]
 description = "each ability is only calculated once"
 include = false
+comment = "gleam is immutable so an ability can not change once the character is created"

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -14,62 +14,48 @@ description = "parsing and numbers -> numbers just get pushed onto the stack"
 
 [fd7a8da2-6818-4203-a866-fed0714e7aa0]
 description = "parsing and numbers -> pushes negative numbers onto the stack"
-include = false
 
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
 description = "addition -> can add two numbers"
-include = false
 
 [52336dd3-30da-4e5c-8523-bdf9a3427657]
 description = "addition -> errors if there is nothing on the stack"
-include = false
 
 [06efb9a4-817a-435e-b509-06166993c1b8]
 description = "addition -> errors if there is only one value on the stack"
-include = false
 
 [09687c99-7bbc-44af-8526-e402f997ccbf]
 description = "subtraction -> can subtract two numbers"
-include = false
 
 [5d63eee2-1f7d-4538-b475-e27682ab8032]
 description = "subtraction -> errors if there is nothing on the stack"
-include = false
 
 [b3cee1b2-9159-418a-b00d-a1bb3765c23b]
 description = "subtraction -> errors if there is only one value on the stack"
-include = false
 
 [5df0ceb5-922e-401f-974d-8287427dbf21]
 description = "multiplication -> can multiply two numbers"
-include = false
 
 [9e004339-15ac-4063-8ec1-5720f4e75046]
 description = "multiplication -> errors if there is nothing on the stack"
-include = false
 
 [8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
 description = "multiplication -> errors if there is only one value on the stack"
-include = false
 
 [e74c2204-b057-4cff-9aa9-31c7c97a93f5]
 description = "division -> can divide two numbers"
-include = false
 
 [54f6711c-4b14-4bb0-98ad-d974a22c4620]
 description = "division -> performs integer division"
-include = false
 
 [a5df3219-29b4-4d2f-b427-81f82f42a3f1]
 description = "division -> errors if dividing by zero"
 
 [1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
 description = "division -> errors if there is nothing on the stack"
-include = false
 
 [d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
 description = "division -> errors if there is only one value on the stack"
-include = false
 
 [ee28d729-6692-4a30-b9be-0d830c52a68c]
 description = "combined arithmetic -> addition and subtraction"
@@ -124,7 +110,6 @@ description = "user-defined words -> can consist of built-in words"
 
 [2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
 description = "user-defined words -> execute in the right order"
-include = false
 
 [9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
 description = "user-defined words -> can override other user-defined words"
@@ -134,26 +119,21 @@ description = "user-defined words -> can override built-in words"
 
 [588de2f0-c56e-4c68-be0b-0bb1e603c500]
 description = "user-defined words -> can override built-in operators"
-include = false
 
 [ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
 description = "user-defined words -> can use different words with the same name"
-include = false
 
 [53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
 description = "user-defined words -> can define word that uses word with the same name"
-include = false
 
 [35958cee-a976-4a0f-9378-f678518fa322]
 description = "user-defined words -> cannot redefine non-negative numbers"
 
 [df5b2815-3843-4f55-b16c-c3ed507292a7]
 description = "user-defined words -> cannot redefine negative numbers"
-include = false
 
 [5180f261-89dd-491e-b230-62737e09806f]
 description = "user-defined words -> errors if executing a non-existent word"
-include = false
 
 [3c8bfef3-edbb-49c1-9993-21d4030043cb]
 description = "user-defined words -> only defines locally"
@@ -161,24 +141,18 @@ include = false
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
 description = "case-insensitivity -> DUP is case-insensitive"
-include = false
 
 [339ed30b-f5b4-47ff-ab1c-67591a9cd336]
 description = "case-insensitivity -> DROP is case-insensitive"
-include = false
 
 [ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
 description = "case-insensitivity -> SWAP is case-insensitive"
-include = false
 
 [acdc3a49-14c8-4cc2-945d-11edee6408fa]
 description = "case-insensitivity -> OVER is case-insensitive"
-include = false
 
 [5934454f-a24f-4efc-9fdd-5794e5f0c23c]
 description = "case-insensitivity -> user-defined words are case-insensitive"
-include = false
 
 [037d4299-195f-4be7-a46d-f07ca6280a06]
 description = "case-insensitivity -> definitions are case-insensitive"
-include = false

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -138,6 +138,7 @@ description = "user-defined words -> errors if executing a non-existent word"
 [3c8bfef3-edbb-49c1-9993-21d4030043cb]
 description = "user-defined words -> only defines locally"
 include = false
+comment = "not included because Gleam is immutable, there is no global state that could be shared by different Forth interpreters"
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
 description = "case-insensitivity -> DUP is case-insensitive"

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -110,6 +110,8 @@ description = "user-defined words -> can consist of built-in words"
 
 [2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
 description = "user-defined words -> execute in the right order"
+include = false
+comment = "the example needs a fix and can't handle this case"
 
 [9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
 description = "user-defined words -> can override other user-defined words"
@@ -122,9 +124,13 @@ description = "user-defined words -> can override built-in operators"
 
 [ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
 description = "user-defined words -> can use different words with the same name"
+include = false
+comment = "the example needs a fix and can't handle this case"
 
 [53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
 description = "user-defined words -> can define word that uses word with the same name"
+include = false
+comment = "the example needs a fix and can't handle this case"
 
 [35958cee-a976-4a0f-9378-f678518fa322]
 description = "user-defined words -> cannot redefine non-negative numbers"

--- a/exercises/practice/forth/test/forth_test.gleam
+++ b/exercises/practice/forth/test/forth_test.gleam
@@ -231,13 +231,13 @@ pub fn calling_a_nonexistent_word_test() {
   |> error_with(forth.UnknownWord)
 }
 
-pub fn user_defined_words_execute_in_the_right_order_test() {
-  forth.new()
-  |> forth.eval(": countup 1 2 3 ;")
-  |> result.then(forth.eval(_, "countup"))
-  |> result.map(forth.format_stack)
-  |> succeed_with("1 2 3")
-}
+//pub fn user_defined_words_execute_in_the_right_order_test() {
+//  forth.new()
+//  |> forth.eval(": countup 1 2 3 ;")
+//  |> result.then(forth.eval(_, "countup"))
+//  |> result.map(forth.format_stack)
+//  |> succeed_with("1 2 3")
+//}
 
 pub fn user_defined_words_can_override_builtin_operators_test() {
   forth.new()
@@ -247,24 +247,24 @@ pub fn user_defined_words_can_override_builtin_operators_test() {
   |> succeed_with("12")
 }
 
-pub fn user_defined_words_can_use_different_words_with_the_same_name_test() {
-  forth.new()
-  |> forth.eval(": foo 5 ;")
-  |> result.then(forth.eval(_, ": bar foo ;"))
-  |> result.then(forth.eval(_, ": foo 6 ;"))
-  |> result.then(forth.eval(_, "bar foo"))
-  |> result.map(forth.format_stack)
-  |> succeed_with("5 6")
-}
+//pub fn user_defined_words_can_use_different_words_with_the_same_name_test() {
+//  forth.new()
+//  |> forth.eval(": foo 5 ;")
+//  |> result.then(forth.eval(_, ": bar foo ;"))
+//  |> result.then(forth.eval(_, ": foo 6 ;"))
+//  |> result.then(forth.eval(_, "bar foo"))
+//  |> result.map(forth.format_stack)
+//  |> succeed_with("5 6")
+//}
 
-pub fn user_defined_words_can_define_word_that_uses_word_with_the_same_name_test() {
-  forth.new()
-  |> forth.eval(": foo 10 ;")
-  |> result.then(forth.eval(_, ": foo foo 1 + ;"))
-  |> result.then(forth.eval(_, "foo"))
-  |> result.map(forth.format_stack)
-  |> succeed_with("11")
-}
+//pub fn user_defined_words_can_define_word_that_uses_word_with_the_same_name_test() {
+//  forth.new()
+//  |> forth.eval(": foo 10 ;")
+//  |> result.then(forth.eval(_, ": foo foo 1 + ;"))
+//  |> result.then(forth.eval(_, "foo"))
+//  |> result.map(forth.format_stack)
+//  |> succeed_with("11")
+//}
 
 pub fn user_defined_words_cannot_redefine_non_negative_numbers_test() {
   forth.new()

--- a/exercises/practice/forth/test/forth_test.gleam
+++ b/exercises/practice/forth/test/forth_test.gleam
@@ -231,14 +231,6 @@ pub fn calling_a_nonexistent_word_test() {
   |> error_with(forth.UnknownWord)
 }
 
-//pub fn user_defined_words_execute_in_the_right_order_test() {
-//  forth.new()
-//  |> forth.eval(": countup 1 2 3 ;")
-//  |> result.then(forth.eval(_, "countup"))
-//  |> result.map(forth.format_stack)
-//  |> succeed_with("1 2 3")
-//}
-
 pub fn user_defined_words_can_override_builtin_operators_test() {
   forth.new()
   |> forth.eval(": + * ;")
@@ -246,25 +238,6 @@ pub fn user_defined_words_can_override_builtin_operators_test() {
   |> result.map(forth.format_stack)
   |> succeed_with("12")
 }
-
-//pub fn user_defined_words_can_use_different_words_with_the_same_name_test() {
-//  forth.new()
-//  |> forth.eval(": foo 5 ;")
-//  |> result.then(forth.eval(_, ": bar foo ;"))
-//  |> result.then(forth.eval(_, ": foo 6 ;"))
-//  |> result.then(forth.eval(_, "bar foo"))
-//  |> result.map(forth.format_stack)
-//  |> succeed_with("5 6")
-//}
-
-//pub fn user_defined_words_can_define_word_that_uses_word_with_the_same_name_test() {
-//  forth.new()
-//  |> forth.eval(": foo 10 ;")
-//  |> result.then(forth.eval(_, ": foo foo 1 + ;"))
-//  |> result.then(forth.eval(_, "foo"))
-//  |> result.map(forth.format_stack)
-//  |> succeed_with("11")
-//}
 
 pub fn user_defined_words_cannot_redefine_non_negative_numbers_test() {
   forth.new()

--- a/exercises/practice/forth/test/forth_test.gleam
+++ b/exercises/practice/forth/test/forth_test.gleam
@@ -32,6 +32,78 @@ pub fn numbers_just_get_pushed_onto_the_stack_test() {
   run_forth_for("1 2 3 4 5", "1 2 3 4 5")
 }
 
+pub fn pushes_negative_numbers_onto_the_stack_test() {
+  run_forth_for("-1 -2 -3 -4 -5", "-1 -2 -3 -4 -5")
+}
+
+pub fn can_add_two_numbers_test() {
+  run_forth_for("1 2 +", "3")
+}
+
+pub fn errors_if_there_is_nothing_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("+")
+  |> error_with(forth.StackUnderflow)
+}
+
+pub fn errors_if_there_is_only_one_value_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("1 +")
+  |> error_with(forth.StackUnderflow)
+}
+
+pub fn can_subtract_two_numbers_test() {
+  run_forth_for("3 4 -", "-1")
+}
+
+pub fn subtraction_errors_if_there_is_nothing_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("-")
+  |> error_with(forth.StackUnderflow)
+}
+
+pub fn subtraction_errors_if_there_is_only_one_value_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("1 -")
+  |> error_with(forth.StackUnderflow)
+}
+
+pub fn can_multiply_two_numbers_test() {
+  run_forth_for("2 4 *", "8")
+}
+
+pub fn multiplication_errors_if_there_is_nothing_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("*")
+  |> error_with(forth.StackUnderflow)
+}
+
+pub fn multiplication_errors_if_there_is_only_one_value_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("1 *")
+  |> error_with(forth.StackUnderflow)
+}
+
+pub fn can_divide_two_numbers_test() {
+  run_forth_for("12 3 /", "4")
+}
+
+pub fn division_performs_integer_division_test() {
+  run_forth_for("8 3 /", "2")
+}
+
+pub fn division_errors_if_there_is_nothing_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("/")
+  |> error_with(forth.StackUnderflow)
+}
+
+pub fn division_errors_if_there_is_only_one_value_on_the_stack_test() {
+  forth.new()
+  |> forth.eval("1 /")
+  |> error_with(forth.StackUnderflow)
+}
+
 pub fn basic_arithmetic_test() {
   run_forth_for("1 2 + 4 -", "-1")
 }
@@ -157,4 +229,89 @@ pub fn calling_a_nonexistent_word_test() {
   forth.new()
   |> forth.eval("1 foo")
   |> error_with(forth.UnknownWord)
+}
+
+pub fn user_defined_words_execute_in_the_right_order_test() {
+  forth.new()
+  |> forth.eval(": countup 1 2 3 ;")
+  |> result.then(forth.eval(_, "countup"))
+  |> result.map(forth.format_stack)
+  |> succeed_with("1 2 3")
+}
+
+pub fn user_defined_words_can_override_builtin_operators_test() {
+  forth.new()
+  |> forth.eval(": + * ;")
+  |> result.then(forth.eval(_, "3 4 +"))
+  |> result.map(forth.format_stack)
+  |> succeed_with("12")
+}
+
+pub fn user_defined_words_can_use_different_words_with_the_same_name_test() {
+  forth.new()
+  |> forth.eval(": foo 5 ;")
+  |> result.then(forth.eval(_, ": bar foo ;"))
+  |> result.then(forth.eval(_, ": foo 6 ;"))
+  |> result.then(forth.eval(_, "bar foo"))
+  |> result.map(forth.format_stack)
+  |> succeed_with("5 6")
+}
+
+pub fn user_defined_words_can_define_word_that_uses_word_with_the_same_name_test() {
+  forth.new()
+  |> forth.eval(": foo 10 ;")
+  |> result.then(forth.eval(_, ": foo foo 1 + ;"))
+  |> result.then(forth.eval(_, "foo"))
+  |> result.map(forth.format_stack)
+  |> succeed_with("11")
+}
+
+pub fn user_defined_words_cannot_redefine_non_negative_numbers_test() {
+  forth.new()
+  |> forth.eval(": 1 2 ;")
+  |> error_with(forth.InvalidWord)
+}
+
+pub fn user_defined_words_cannot_redefine_negative_numbers_test() {
+  forth.new()
+  |> forth.eval(": -1 2 ;")
+  |> error_with(forth.InvalidWord)
+}
+
+pub fn user_defined_words_errors_if_executing_non_existent_word_test() {
+  forth.new()
+  |> forth.eval("foo")
+  |> error_with(forth.UnknownWord)
+}
+
+pub fn dup_is_case_insensitive_test() {
+  run_forth_for("1 DUP Dup dup", "1 1 1 1")
+}
+
+pub fn drop_is_case_insensitive_test() {
+  run_forth_for("1 2 3 4 DROP Drop drop", "1")
+}
+
+pub fn swap_is_case_insensitive_test() {
+  run_forth_for("1 2 SWAP 3 Swap 4 swap", "2 3 4 1")
+}
+
+pub fn over_is_case_insensitive_test() {
+  run_forth_for("1 2 OVER Over over", "1 2 1 2 1")
+}
+
+pub fn user_defined_words_are_case_insensitive_test() {
+  forth.new()
+  |> forth.eval(": foo dup ;")
+  |> result.then(forth.eval(_, "1 FOO Foo foo"))
+  |> result.map(forth.format_stack)
+  |> succeed_with("1 1 1 1")
+}
+
+pub fn definitions_are_case_insensitive_test() {
+  forth.new()
+  |> forth.eval(": SWAP DUP Dup dup ;")
+  |> result.then(forth.eval(_, "1 swap"))
+  |> result.map(forth.format_stack)
+  |> succeed_with("1 1 1 1")
 }

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -14,14 +14,12 @@ description = "Roster is empty when no student is added"
 
 [9337267f-7793-4b90-9b4a-8e3978408824]
 description = "Add a student"
-include = false
 
 [6d0a30e4-1b4e-472e-8e20-c41702125667]
 description = "Student is added to the roster"
 
 [73c3ca75-0c16-40d7-82f5-ed8fe17a8e4a]
 description = "Adding multiple students in the same grade in the roster"
-include = false
 
 [233be705-dd58-4968-889d-fb3c7954c9cc]
 description = "Multiple students in the same grade are added to the roster"
@@ -32,6 +30,7 @@ description = "Cannot add student to same grade in the roster more than once"
 [c125dab7-2a53-492f-a99a-56ad511940d8]
 description = "A student can't be in two different grades"
 include = false
+comment = "not included because reimplemented by a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1"
 
 [a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1]
 description = "A student can only be added to the same grade in the roster once"

--- a/exercises/practice/grade-school/test/grade_school_test.gleam
+++ b/exercises/practice/grade-school/test/grade_school_test.gleam
@@ -13,11 +13,27 @@ pub fn roster_is_empty_when_no_student_is_added_test() {
   |> should.equal([])
 }
 
+pub fn add_a_student() {
+  grade_school.create()
+  |> grade_school.add(student: "Aimee", grade: 2)
+  |> result.map(grade_school.roster)
+  |> should.be_ok
+}
+
 pub fn student_is_added_to_the_roster_test() {
   grade_school.create()
   |> grade_school.add(student: "Aimee", grade: 2)
   |> result.map(grade_school.roster)
   |> should.equal(Ok(["Aimee"]))
+}
+
+pub fn adding_multiple_students_in_the_same_grade_in_the_roster() {
+  grade_school.create()
+  |> grade_school.add(student: "Blair", grade: 2)
+  |> result.then(grade_school.add(to: _, student: "James", grade: 2))
+  |> result.then(grade_school.add(to: _, student: "Paul", grade: 2))
+  |> result.map(grade_school.roster)
+  |> should.be_ok
 }
 
 pub fn multiple_students_in_the_same_grade_are_added_to_the_roster_test() {

--- a/exercises/practice/grade-school/test/grade_school_test.gleam
+++ b/exercises/practice/grade-school/test/grade_school_test.gleam
@@ -13,7 +13,7 @@ pub fn roster_is_empty_when_no_student_is_added_test() {
   |> should.equal([])
 }
 
-pub fn add_a_student() {
+pub fn add_a_student_test() {
   grade_school.create()
   |> grade_school.add(student: "Aimee", grade: 2)
   |> result.map(grade_school.roster)
@@ -27,7 +27,7 @@ pub fn student_is_added_to_the_roster_test() {
   |> should.equal(Ok(["Aimee"]))
 }
 
-pub fn adding_multiple_students_in_the_same_grade_in_the_roster() {
+pub fn adding_multiple_students_in_the_same_grade_in_the_roster_test() {
   grade_school.create()
   |> grade_school.add(student: "Blair", grade: 2)
   |> result.then(grade_school.add(to: _, student: "James", grade: 2))

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -27,6 +27,7 @@ description = "long different strands"
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
 include = false
+comment = "not included because reimplemented by b9228bb1-465f-4141-b40f-1f99812de5a8"
 
 [b9228bb1-465f-4141-b40f-1f99812de5a8]
 description = "disallow first strand longer"
@@ -35,6 +36,7 @@ reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
 include = false
+comment = "not included because reimplemented by dab38838-26bb-4fff-acbe-3b0a9bfeba2d"
 
 [dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
 description = "disallow second strand longer"
@@ -43,11 +45,13 @@ reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
 include = false
+comment = "not included because reimplemented by db92e77e-7c72-499d-8fe6-9354d2bfd504"
 
 [db92e77e-7c72-499d-8fe6-9354d2bfd504]
 description = "disallow left empty strand"
 include = false
 reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+comment = "not included because reimplemented by b764d47c-83ff-4de2-ab10-6cfe4b15c0f3"
 
 [b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
 description = "disallow empty first strand"
@@ -56,11 +60,13 @@ reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
 include = false
+comment = "not included because reimplemented by 920cd6e3-18f4-4143-b6b8-74270bb8f8a3"
 
 [920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
 description = "disallow right empty strand"
 include = false
 reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+comment = "not included because reimplemented by 9ab9262f-3521-4191-81f5-0ed184a5aa89"
 
 [9ab9262f-3521-4191-81f5-0ed184a5aa89]
 description = "disallow empty second strand"

--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -41,11 +41,9 @@ description = "rejects span longer than string length"
 
 [06bc8b90-0c51-4c54-ac22-3ec3893a079e]
 description = "reports 1 for empty string and empty product (0 span)"
-include = false
 
 [3ec0d92e-f2e2-4090-a380-70afee02f4c0]
 description = "reports 1 for nonempty string and empty product (0 span)"
-include = false
 
 [6d96c691-4374-4404-80ee-2ea8f3613dd4]
 description = "rejects empty string and nonzero span"
@@ -56,6 +54,7 @@ description = "rejects invalid character in digits"
 [5fe3c0e5-a945-49f2-b584-f0814b4dd1ef]
 description = "rejects negative span"
 include = false
+comment = "not included because reimplemented by c859f34a-9bfe-4897-9c2f-6d7f8598e7f0"
 
 [c859f34a-9bfe-4897-9c2f-6d7f8598e7f0]
 description = "rejects negative span"

--- a/exercises/practice/largest-series-product/test/largest_series_product_test.gleam
+++ b/exercises/practice/largest-series-product/test/largest_series_product_test.gleam
@@ -44,6 +44,16 @@ pub fn can_get_the_largest_product_of_a_big_number_test() {
   |> should.equal(Ok(23_520))
 }
 
+pub fn reports_one_for_empty_string_and_empty_products() {
+  largest_series_product.largest_product("", 0)
+  |> should.equal(Ok(1))
+}
+
+pub fn reports_one_for_nonempty_string_and_empty_products() {
+  largest_series_product.largest_product("123", 0)
+  |> should.equal(Ok(1))
+}
+
 pub fn reports_zero_if_the_only_digits_are_zero_test() {
   largest_series_product.largest_product("0000", 2)
   |> should.equal(Ok(0))

--- a/exercises/practice/largest-series-product/test/largest_series_product_test.gleam
+++ b/exercises/practice/largest-series-product/test/largest_series_product_test.gleam
@@ -44,12 +44,12 @@ pub fn can_get_the_largest_product_of_a_big_number_test() {
   |> should.equal(Ok(23_520))
 }
 
-pub fn reports_one_for_empty_string_and_empty_products() {
+pub fn reports_one_for_empty_string_and_empty_products_test() {
   largest_series_product.largest_product("", 0)
   |> should.equal(Ok(1))
 }
 
-pub fn reports_one_for_nonempty_string_and_empty_products() {
+pub fn reports_one_for_nonempty_string_and_empty_products_test() {
   largest_series_product.largest_product("123", 0)
   |> should.equal(Ok(1))
 }

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -51,14 +51,17 @@ description = "return a list of elements whose values equal the list value trans
 [613b20b7-1873-4070-a3a6-70ae5f50d7cc]
 description = "folds (reduces) the given list from the left with a function -> empty list"
 include = false
+comment = "not included because reimplemented by 36549237-f765-4a4c-bfd9-5d3a8f7b07d2"
 
 [e56df3eb-9405-416a-b13a-aabb4c3b5194]
 description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
 include = false
+comment = "not included because reimplemented by 7a626a3c-03ec-42bc-9840-53f280e13067"
 
 [d2cf5644-aee1-4dfc-9b88-06896676fe27]
 description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
 include = false
+comment = "not included because reimplemented by d7fcad99-e88e-40e1-a539-4c519681f390"
 
 [36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
 description = "folds (reduces) the given list from the left with a function -> empty list"
@@ -75,14 +78,17 @@ reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
 [aeb576b9-118e-4a57-a451-db49fac20fdc]
 description = "folds (reduces) the given list from the right with a function -> empty list"
 include = false
+comment = "not included because reimplemented by 17214edb-20ba-42fc-bda8-000a5ab525b0"
 
 [c4b64e58-313e-4c47-9c68-7764964efb8e]
 description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
 include = false
+comment = "not included because reimplemented by e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd"
 
 [be396a53-c074-4db3-8dd6-f7ed003cce7c]
 description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
 include = false
+comment = "not included because reimplemented by 8066003b-f2ff-437e-9103-66e6df474844"
 
 [17214edb-20ba-42fc-bda8-000a5ab525b0]
 description = "folds (reduces) the given list from the right with a function -> empty list"

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -39,6 +39,7 @@ description = "mixed case and punctuation"
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
 include = false
+comment = "not included because reimplemented by 7138e389-83e4-4c6e-8413-1e40a0076951"
 
 [7138e389-83e4-4c6e-8413-1e40a0076951]
 description = "a-m and A-M are 26 different characters but not a pangram"

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -11,7 +11,6 @@
 
 [9920ce55-9629-46d5-85d6-4201f4a4234d]
 description = "zero rows"
-include = false
 
 [70d643ce-a46d-4e93-af58-12d88dd01f21]
 description = "single row"
@@ -30,8 +29,6 @@ description = "five rows"
 
 [c3912965-ddb4-46a9-848e-3363e6b00b13]
 description = "six rows"
-include = false
 
 [6cb26c66-7b57-4161-962c-81ec8c99f16b]
 description = "ten rows"
-include = false

--- a/exercises/practice/pascals-triangle/test/pascals_triangle_test.gleam
+++ b/exercises/practice/pascals-triangle/test/pascals_triangle_test.gleam
@@ -8,6 +8,11 @@ pub fn main() {
   gleeunit.main()
 }
 
+pub fn zero_rows_test() {
+  pascals_triangle.rows(0)
+  |> should.equal([])
+}
+
 pub fn one_row_test() {
   pascals_triangle.rows(1)
   |> should.equal([[1]])
@@ -21,6 +26,34 @@ pub fn two_rows_test() {
 pub fn three_rows_test() {
   pascals_triangle.rows(3)
   |> should.equal([[1], [1, 1], [1, 2, 1]])
+}
+
+pub fn six_rows_test() {
+  pascals_triangle.rows(6)
+  |> should.equal([
+    [1],
+    [1, 1],
+    [1, 2, 1],
+    [1, 3, 3, 1],
+    [1, 4, 6, 4, 1],
+    [1, 5, 10, 10, 5, 1],
+  ])
+}
+
+pub fn ten_rows_test() {
+  pascals_triangle.rows(10)
+  |> should.equal([
+    [1],
+    [1, 1],
+    [1, 2, 1],
+    [1, 3, 3, 1],
+    [1, 4, 6, 4, 1],
+    [1, 5, 10, 10, 5, 1],
+    [1, 6, 15, 20, 15, 6, 1],
+    [1, 7, 21, 35, 35, 21, 7, 1],
+    [1, 8, 28, 56, 70, 56, 28, 8, 1],
+    [1, 9, 36, 84, 126, 126, 84, 36, 9, 1],
+  ])
 }
 
 pub fn fourth_row_test() {

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -21,6 +21,7 @@ description = "cleans numbers with multiple spaces"
 [598d8432-0659-4019-a78b-1c6a73691d21]
 description = "invalid when 9 digits"
 include = false
+comment = "not included because reimplemented by 2de74156-f646-42b5-8638-0ef1d8b58bc2"
 
 [2de74156-f646-42b5-8638-0ef1d8b58bc2]
 description = "invalid when 9 digits"
@@ -38,6 +39,7 @@ description = "valid when 11 digits and starting with 1 even with punctuation"
 [c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
 description = "invalid when more than 11 digits"
 include = false
+comment = "not included because reimplemented by 4a1509b7-8953-4eec-981b-c483358ff531"
 
 [4a1509b7-8953-4eec-981b-c483358ff531]
 description = "invalid when more than 11 digits"
@@ -46,6 +48,7 @@ reimplements = "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad"
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"
 include = false
+comment = "not included because reimplemented by eb8a1fc0-64e5-46d3-b0c6-33184208e28a"
 
 [eb8a1fc0-64e5-46d3-b0c6-33184208e28a]
 description = "invalid with letters"
@@ -54,6 +57,7 @@ reimplements = "63f38f37-53f6-4a5f-bd86-e9b404f10a60"
 [4bd97d90-52fd-45d3-b0db-06ab95b1244e]
 description = "invalid with punctuations"
 include = false
+comment = "not included because reimplemented by 065f6363-8394-4759-b080-e6c8c351dd1f"
 
 [065f6363-8394-4759-b080-e6c8c351dd1f]
 description = "invalid with punctuations"

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -11,7 +11,6 @@
 
 [2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98]
 description = "Empty RNA sequence results in no proteins"
-include = false
 
 [96d3d44f-34a2-4db4-84cd-fff523e069be]
 description = "Methionine RNA sequence"
@@ -99,4 +98,3 @@ description = "Incomplete RNA sequence can't translate"
 
 [43945cf7-9968-402d-ab9f-b8a28750b050]
 description = "Incomplete RNA sequence can translate if valid until a STOP codon"
-include = false

--- a/exercises/practice/protein-translation/test/protein_translation_test.gleam
+++ b/exercises/practice/protein-translation/test/protein_translation_test.gleam
@@ -6,6 +6,12 @@ pub fn main() {
   gleeunit.main()
 }
 
+pub fn empty_rna_sequence_results_in_no_proteins_test() {
+  ""
+  |> protein_translation.proteins
+  |> should.equal(Ok([]))
+}
+
 pub fn methione_rna_sequence_test() {
   "AUG"
   |> protein_translation.proteins
@@ -172,4 +178,10 @@ pub fn translation_stops_if_stop_codon_in_middle_of_six_codon_sequence_test() {
   "UGGUGUUAUUAAUGGUUU"
   |> protein_translation.proteins
   |> should.equal(Ok(["Tryptophan", "Cysteine", "Tyrosine"]))
+}
+
+pub fn incomplete_rna_sequence_can_translate_if_valid_until_a_stop_codon_test() {
+  "UUCUUCUAAUGGU"
+  |> protein_translation.proteins
+  |> should.equal(Ok(["Phenylalanine", "Phenylalanine"]))
 }

--- a/exercises/practice/saddle-points/.meta/tests.toml
+++ b/exercises/practice/saddle-points/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[3e374e63-a2e0-4530-a39a-d53c560382bd]
+description = "Can identify single saddle point"
+
+[6b501e2b-6c1f-491f-b1bb-7f278f760534]
+description = "Can identify that empty matrix has no saddle points"
+
+[8c27cc64-e573-4fcb-a099-f0ae863fb02f]
+description = "Can identify lack of saddle points when there are none"
+
+[6d1399bd-e105-40fd-a2c9-c6609507d7a3]
+description = "Can identify multiple saddle points in a column"
+
+[3e81dce9-53b3-44e6-bf26-e328885fd5d1]
+description = "Can identify multiple saddle points in a row"
+
+[88868621-b6f4-4837-bb8b-3fad8b25d46b]
+description = "Can identify saddle point in bottom right corner"
+
+[5b9499ca-fcea-4195-830a-9c4584a0ee79]
+description = "Can identify saddle points in a non square matrix"
+
+[ee99ccd2-a1f1-4283-ad39-f8c70f0cf594]
+description = "Can identify that saddle points in a single column matrix are those with the minimum value"
+
+[63abf709-a84b-407f-a1b3-456638689713]
+description = "Can identify that saddle points in a single row matrix are those with the maximum value"

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -24,6 +24,9 @@ description = "jump for 1000"
 [40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
 description = "combine two actions"
 
+[9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
+description = "reverse two actions"
+
 [0b828205-51ca-45cd-90d5-f2506013f25f]
 description = "reversing one action gives the same action"
 

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -36,6 +36,7 @@ description = "normalize case"
 [4185a902-bdb0-4074-864c-f416e42a0f19]
 description = "with apostrophes"
 include = false
+comment = "not included because reimplemented by 4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3"
 
 [4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3]
 description = "with apostrophes"


### PR DESCRIPTION
I ran `bin/configlet sync --tests --update` to update any dated test. Moreover, I looked for all occurrences of `include = false` in the codebase and either implemented the missing test or added a reason why the test is missing:
- any test that is reimplemented by another now explains that that is the reason why it is not included
- all tests that were meant to rule out mutable state were ignored with a proper reason
- all other tests were not hard to implement so I added them all

Since now there is no missing test and all tests that are not included were properly commented this should close #134 

Edit: there is one exception that is the Forth case: there are 3 tests that were previously ignored that the example doesn't pass. This would require fixing the forth example, I think this PR is already big enough so I've opened a new issue and will start working on that