### PR TITLE
Predefine do_insert instead of do_delete in erlang_extraction

### DIFF
--- a/exercises/concept/erlang-extraction/src/erlang_extraction.gleam
+++ b/exercises/concept/erlang-extraction/src/erlang_extraction.gleam
@@ -8,10 +8,6 @@ pub fn insert(tree: GbTree(k, v), key: k, value: v) -> GbTree(k, v) {
   todo
 }
 
-fn do_insert(key: k, value: v, tree: GbTree(k, v)) -> GbTree(k, v) {
-  todo
-}
-
 pub fn delete(tree: GbTree(k, v), key: k) -> GbTree(k, v) {
   todo
 }

--- a/exercises/concept/erlang-extraction/src/erlang_extraction.gleam
+++ b/exercises/concept/erlang-extraction/src/erlang_extraction.gleam
@@ -8,10 +8,10 @@ pub fn insert(tree: GbTree(k, v), key: k, value: v) -> GbTree(k, v) {
   todo
 }
 
-pub fn delete(tree: GbTree(k, v), key: k) -> GbTree(k, v) {
+fn do_insert(key: k, value: v, tree: GbTree(k, v)) -> GbTree(k, v) {
   todo
 }
 
-fn do_delete(key: k, tree: GbTree(k, v)) -> GbTree(k, v) {
+pub fn delete(tree: GbTree(k, v), key: k) -> GbTree(k, v) {
   todo
 }


### PR DESCRIPTION
Because writing the insert function is the ~second~third task, I think it's more beneficial as a hint to predefine the private do_ function there so that beginners are not stuck on the different order of arguments. And then we can let the student figure this out on their own for the delete function