### PR TITLE
Fix deletion hints for Erlang Extraction

### DIFF
--- a/exercises/concept/erlang-extraction/.docs/hints.md
+++ b/exercises/concept/erlang-extraction/.docs/hints.md
@@ -16,6 +16,7 @@
 
 ## 4. Define the `delete` function
 
-- The function should use the `gb_trees:delete_any/3`.
-- The `gb_trees:delete/3` function will crash if the key is not found, so it should not be used.
+- The external function can be a private function that is called by the `delete` function in order to change the order of the arguments.
+- The function should use the `gb_trees:delete_any/2`.
+- The `gb_trees:delete/2` function will crash if the key is not found, so it should not be used.
 


### PR DESCRIPTION
Hello! This is a fix for #370 😃

Delete functions take two parameters, not three. I've also added a hint for the parameter order.