### PR TITLE
Update casing for Nucleotide Count in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1245,7 +1245,7 @@
       },
       {
         "slug": "nucleotide-count",
-        "name": "Nucleotide count",
+        "name": "Nucleotide Count",
         "uuid": "3b7e1bbf-08b2-4e0e-ba5d-5a887deb4817",
         "practices": [
         ],


### PR DESCRIPTION
All other exercise names are in Capitalized Case so this inconsistency stands out when reading the exercise list at https://exercism.org/tracks/gleam/exercises