### PR TITLE
Use BitArray & :bits nomenclature

### DIFF
--- a/exercises/concept/dna-encoding/.docs/instructions.md
+++ b/exercises/concept/dna-encoding/.docs/instructions.md
@@ -32,16 +32,16 @@ decode_nucleotide(0b01)
 
 ## 3. Encode a DNA list
 
-Implement `encode` to accept a list of nucleotides and return a bit string of the encoded data.
+Implement `encode` to accept a list of nucleotides and return a bit array of the encoded data.
 
 ```gleam
 encode([Adenine, Cytosine, Guanine, Thymine])
 // -> <<27>>
 ```
 
-## 4. Decode a DNA bitstring
+## 4. Decode a DNA bit array
 
-Implement `decode` to accept a bit string representing nucleic acid and return the decoded data as a charlist.
+Implement `decode` to accept a bit array representing nucleic acid and return the decoded data as a list of nucleotides.
 
 ```gleam
 decode(<<27>>)

--- a/exercises/concept/dna-encoding/.docs/introduction.md
+++ b/exercises/concept/dna-encoding/.docs/introduction.md
@@ -1,16 +1,16 @@
 # Introduction
 
-## Bit Strings
+## Bit Arrays
 
-Working with binary data can be tricky, so Gleam provides a `BitString` type and accompanying syntax to construct and to pattern match on binary data.
+Working with binary data can be tricky, so Gleam provides a `BitArray` type and accompanying syntax to construct and to pattern match on binary data.
 
-Bit string literals are defined using the `<<>>` syntax. When defining a bit string literal, it is defined in segments. Each segment has a value and annotation, separated by a `:`. The annotation specifies how many bits will be used to encode the value, and can be omitted completely, which will default to a 8-bit integer value.
+Bit array literals are defined using the `<<>>` syntax. When defining a bit array literal, it is defined in segments. Each segment has a value and annotation, separated by a `:`. The annotation specifies how many bits will be used to encode the value, and can be omitted completely, which will default to a 8-bit integer value.
 
 ```gleam
-// This defines a bit string with three segments of a single bit each
+// This defines a bit array with three segments of a single bit each
 <<0:1, 1:1, 0:1>>
 
-// This defines a bit string with three segments of 8 bits each
+// This defines a bit array with three segments of 8 bits each
 <<0, 1, 0>>
 ```
 
@@ -41,50 +41,50 @@ If the value of the segment overflows the capacity of the segment's type, it wil
 
 ### Prepending and appending
 
-You can both prepend and append to an existing bit string using the bit string syntax. The `:bit_string` annotation must be used for the existing bit string.
+You can both prepend and append to an existing bit array using the bit array syntax. The `:bits` annotation must be used for the existing bit array.
 
 ```gleam
 let value = <<0b110:3, 0b001:3>>
-let new_value = <<0b011:3, value:bit_string, 0b000:3>>
+let new_value = <<0b011:3, value:bits, 0b000:3>>
 // -> <<120, 8:size(4)>>
 ```
 
 ### Concatenating
 
-We can concatenate bit strings stored in variables using the syntax. The `:bit_string` annotation must be used when concatenating two bit strings of variable sizes.
+We can concatenate bit arrays stored in variables using the bit array syntax. The `:bits` annotation must be used when concatenating two bit strings of variable sizes.
 
 ```gleam
 let first = <<0b110:3>>
 let second = <<0b001:3>>
-let concatenated = <<first:bit_string, second:bit_string>>
+let concatenated = <<first:bits, second:bits>>
 // -> <<49:size(6)>>
 ```
 
 ### Pattern matching
 
-Pattern matching can also be done to obtain values from the bit string. You have to know the number of bits for each fragment you want to capture, with one exception: the `:bit_string` annotation can be used to pattern match on a bit string of an unknown size, but this can only be used for the last fragment.
+Pattern matching can also be done to obtain values from the bit array. You have to know the number of bits for each segment you want to capture, with one exception: the `:bits` annotation can be used to pattern match on a bit array of an unknown size, but this can only be used for the last segment.
 
 ```gleam
-let assert <<value:4, rest:bit_string>> = <<0b01101001:8>>
+let assert <<value:4, rest:bits>> = <<0b01101001:8>>
 value == 0b0110
 // -> True
 ```
 
-### Inspecting bit strings
+### Inspecting bit arrays
 
 ~~~~exercism/note
-Bit strings might be printed in a different format than the format that was used
-to create them. This often causes confusion when learning bit strings.
+Bit arrays might be printed in a different format than the format that was used
+to create them. This often causes confusion when learning bit arrays.
 ~~~~
 
-By default, bit strings are displayed in fragments of 8 bits (a byte), even if you created them with fragments of a different size.
+By default, bit arrays are displayed in segments of 8 bits (a byte), even if you created them with segments of a different size.
 
 ```gleam
 <<2011:11>>
 // -> <<251, 3:size(3)>>
 ```
 
-If you create a bit string that represents a printable UTF-8 encoded string, it may displayed as a string by functions such as `io.debug`. This is due to an implementation detail of how Gleam represents strings internally.
+If you create a bit array that represents a printable UTF-8 encoded string, it may displayed as a string by functions such as `io.debug`. This is due to an implementation detail of how Gleam represents strings internally.
 
 ```gleam
 <<>>


### PR DESCRIPTION
Per updates in gleam 0.32 (see https://gleam.run/news/v0.32-polishing-syntax-for-stability/), this updates the language used as follows:

* `BitString` becomes `BitArray`
* "bit string" becomes "bit array"
* `:bit_string` becomes `:bits`

Also, when referring to sub-sections of bit arrays, "segment" seems to be the term of choice, so a few occurrences of "fragment" were changes to "segment".  FWIW, "segment" is also the term used in [The Gleam Book](https://gleam.run/book/tour/bit-strings.html).