### PR TITLE
Add missing test for low-level full mana requirement `Role Playing Game`

### DIFF
--- a/exercises/concept/role-playing-game/.docs/instructions.md
+++ b/exercises/concept/role-playing-game/.docs/instructions.md
@@ -24,7 +24,7 @@ If they are, it should return a new `Player` instance with 100 health.
 Otherwise, if the player's character isn't dead, the `revive` function returns `None`.
 
 If the player's level is 10 or above, they should also be revived with 100 mana.
-If they player's level is below 10, their mana should be `None`.
+If they player's level is below 10, their mana should be untouched.
 The `revive` function should preserve the player's level.
 
 ```gleam

--- a/exercises/concept/role-playing-game/test/role_playing_game_test.gleam
+++ b/exercises/concept/role-playing-game/test/role_playing_game_test.gleam
@@ -25,8 +25,8 @@ pub fn revive_a_player_that_is_alive_should_return_none_test() {
   |> should.equal(None)
 }
 
-pub fn reviving_a_low_level_player_resets_health_and_removes_mana_test() {
-  Player(name: None, level: 3, health: 0, mana: Some(7))
+pub fn reviving_a_low_level_player_resets_its_health_to_100_test() {
+  Player(name: None, level: 3, health: 0, mana: None)
   |> role_playing_game.revive
   |> should.equal(Some(Player(name: None, level: 3, health: 100, mana: None)))
 }

--- a/exercises/concept/role-playing-game/test/role_playing_game_test.gleam
+++ b/exercises/concept/role-playing-game/test/role_playing_game_test.gleam
@@ -25,8 +25,8 @@ pub fn revive_a_player_that_is_alive_should_return_none_test() {
   |> should.equal(None)
 }
 
-pub fn reviving_a_low_level_player_resets_its_health_to_100_test() {
-  Player(name: None, level: 3, health: 0, mana: None)
+pub fn reviving_a_low_level_player_resets_health_and_removes_mana_test() {
+  Player(name: None, level: 3, health: 0, mana: Some(7))
   |> role_playing_game.revive
   |> should.equal(Some(Player(name: None, level: 3, health: 100, mana: None)))
 }


### PR DESCRIPTION
The problem description states: `If they player's level is below 10, their mana should be None`. One of the top results did not implement this requirement due to a missing test. 

This PR modifies a test verifying that low level players get their `mana` set to `None`.

@Reviewer: If preferred, i can also add a new test instead modifying the current test. 

