### PR TITLE
Corrected argument typo

### DIFF
--- a/exercises/concept/secrets/.docs/instructions.md
+++ b/exercises/concept/secrets/.docs/instructions.md
@@ -40,7 +40,7 @@ Implement `secret_divide`. It should return a function which takes one argument 
 
 ```gleam
 let divider = secret_divide(3)
-divider(32)
+divider(30)
 // -> 10
 ```
 


### PR DESCRIPTION
If the intended return for the function is 10 then the argument in the divider function should be 30.