### PR TITLE
Update instructions.md for high-school-sweetheart exercise

### DIFF
--- a/exercises/concept/high-school-sweetheart/.docs/instructions.md
+++ b/exercises/concept/high-school-sweetheart/.docs/instructions.md
@@ -48,7 +48,7 @@ initials("Lance Green")
 
 ## 4. Put the initials inside of the heart
 
-Implement the `pair/2` function. It should take two full names and return the initials inside an ASCII heart. Make sure to reuse `initials` that you defined in the previous step.
+Implement the `pair` function. It should take two full names and return the initials inside an ASCII heart. Make sure to reuse `initials` that you defined in the previous step.
 
 ```gleam
 pair("Blake Miller", "Riley Lewis")


### PR DESCRIPTION
Change function notation from `pair/2` to `pair`.

I haven't seen this function notation for Gleam in the Exercism track so far nor in the [Gleam language tour](https://tour.gleam.run/) and I only know about Gleam since v1.0.
So I don't know if it's a pre-v1.0 exercise artefact and the notation got removed or if it's something that should be presented prior to this exercise to avoid confusion about the "/2".