### PR TITLE
fix role_playing_game test according to instructions

### DIFF
--- a/exercises/concept/role-playing-game/test/role_playing_game_test.gleam
+++ b/exercises/concept/role-playing-game/test/role_playing_game_test.gleam
@@ -26,9 +26,11 @@ pub fn revive_a_player_that_is_alive_should_return_none_test() {
 }
 
 pub fn reviving_a_low_level_player_resets_its_health_to_100_test() {
-  Player(name: None, level: 3, health: 0, mana: None)
+  Player(name: None, level: 3, health: 0, mana: Some(3))
   |> role_playing_game.revive
-  |> should.equal(Some(Player(name: None, level: 3, health: 100, mana: None)))
+  |> should.equal(
+    Some(Player(name: None, level: 3, health: 100, mana: Some(3))),
+  )
 }
 
 pub fn reviving_a_high_level_player_resets_both_its_health_and_mana_test() {


### PR DESCRIPTION
The exercise's instructions say: "If they player's level is below 10, their mana should be untouched."

Since the test checked against `None` there were unintended solutions that did not account for the player level, such as:

`Some(Player(..player, health: 100, mana: option.map(player.mana, fn(_){ 100 })))`