### PR TITLE
changed: simplify a phrase to improve clarity

### DIFF
--- a/exercises/concept/bandwagoner/.docs/hints.md
+++ b/exercises/concept/bandwagoner/.docs/hints.md
@@ -11,5 +11,5 @@
 ## 7. Check if you should root for a team
 
 - The best way to execute logic based on the team's value is to use a case expression.
-- If you want to add an additional condition to a pattern, you can add a guard.
+- If you want to add a condition to a pattern, you can use a guard.
 - Pattern matching works for records within records.

--- a/exercises/concept/bandwagoner/.docs/instructions.md
+++ b/exercises/concept/bandwagoner/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-In this exercise you're a big sports fan and you've just discovered a passion for NBA basketball. Being new to NBA basketball, you're doing a deep dive into NBA history, keeping track of teams, coaches, their win/loss stats and comparing them against each other.
+In this exercise you're a big sports fan and you've just discovered a passion for NBA basketball. Being new to NBA basketball, you're doing a deep dive into NBA history, keeping track of teams, coaches, their win/loss stats, and comparing them against each other.
 
 As you don't yet have a favorite team, you'll also be developing an algorithm to figure out whether to root for a particular team.
 


### PR DESCRIPTION
Consider simplifying the phrase to improve clarity. For example, "add an additional" can be redundant. But in the end both phrases are fine, you can choose which one to keep it.