### PR TITLE
changed to use dash for markdown unordered list

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -4,7 +4,7 @@ The official [Gleam language tour](https://gleam.run/book/tour/) is an excellent
 
 ## Additional learning resources
 
-* [Gleam Documentation](https://gleam.run)
+- [Gleam Documentation](https://gleam.run)
 - [Gleam for Elixir users](https://gleam.run/cheatsheets/gleam-for-elixir-users)
 - [Gleam for Elm users](https://gleam.run/cheatsheets/gleam-for-elm-users)
 - [Gleam for Erlang users](https://gleam.run/cheatsheets/gleam-for-erlang-users)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -2,17 +2,16 @@
 
 ## Gleam Documentation
 
-* [Gleam website](https://gleam.run/)
-* [Gleam language tour](https://gleam.run/book/tour/)
-* [Gleam standard library](https://hexdocs.pm/gleam_stdlib/)
-* [Hex](https://hex.pm/) - a package manager for the Erlang ecosystem
+- [Gleam website](https://gleam.run/)
+- [Gleam language tour](https://gleam.run/book/tour/)
+- [Gleam standard library](https://hexdocs.pm/gleam_stdlib/)
+- [Hex](https://hex.pm/) - a package manager for the Erlang ecosystem
 
 ## Communication channels
 
-* [Gleam Discord Forum](https://discord.gg/Fm8Pwmy)
-* [Gleam GitHub Discussions](https://github.com/gleam-lang/gleam/discussions/)
+- [Gleam Discord Forum](https://discord.gg/Fm8Pwmy)
+- [Gleam GitHub Discussions](https://github.com/gleam-lang/gleam/discussions/)
 
 ## Gleam Newsletters
 
 - [The Gleam newsletter](https://gleam.run/mailing-list/)
-


### PR DESCRIPTION
I noticed some places where using both `*` and `-` to represent unorderd list, I believe the default being used is `-`