### PR TITLE
Fixed a typo in instructions.md

### DIFF
--- a/exercises/concept/erlang-extraction/.docs/instructions.md
+++ b/exercises/concept/erlang-extraction/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Tadhg has found the perfect Erlang library to help with is project. Being an older Erlang library it is using the `gb_trees` module rather than the newer `maps` module for storing data.
+Tadhg has found the perfect Erlang library to help with his project. Being an older Erlang library it is using the `gb_trees` module rather than the newer `maps` module for storing data.
 
 Help out Tadgh by creating external types and functions for working with `gb_trees` in Gleam.
 


### PR DESCRIPTION
Found a typo while doing the gleam exercises. This PR fixes it.