### PR TITLE
Fix total_yen_test case in sticker-shop exercise

### DIFF
--- a/exercises/concept/sticker-shop/test/sticker_shop_test.gleam
+++ b/exercises/concept/sticker-shop/test/sticker_shop_test.gleam
@@ -94,12 +94,12 @@ pub fn total_euros_test() {
 
 pub fn total_yen_test() {
   [
-    sticker_shop.euro(480),
-    sticker_shop.euro(340),
-    sticker_shop.euro(455),
-    sticker_shop.euro(165),
-    sticker_shop.euro(100),
+    sticker_shop.yen(480),
+    sticker_shop.yen(340),
+    sticker_shop.yen(455),
+    sticker_shop.yen(165),
+    sticker_shop.yen(100),
   ]
   |> sticker_shop.total
-  |> should.equal(sticker_shop.euro(1540))
+  |> should.equal(sticker_shop.yen(1540))
 }


### PR DESCRIPTION
This PR is updating the `total_yen_test` case to use Yen currency.

For now the test case is using Euro currency while we should check if the `sticker_shop.total` function is working as expected with Yen currency.