### PR TITLE
Added missing comma to introduction of wine cellar exercise

### DIFF
--- a/exercises/concept/wine-cellar/.docs/introduction.md
+++ b/exercises/concept/wine-cellar/.docs/introduction.md
@@ -19,7 +19,7 @@ pub fn replace(
 When calling a function with labelled arguments the arguments can be given in any order. Each of these calls to `replace` are equivalent:
 
 ```gleam
-replace(in: "🍔🍔🍔" each: "🍔", with: "🍕")
+replace(in: "🍔🍔🍔", each: "🍔", with: "🍕")
 
 replace(each: "🍔", in: "🍔🍔🍔", with: "🍕")
 


### PR DESCRIPTION
Fixes a syntax error in the introduction.

```gleam
error: Syntax error
  ┌─ /src/main.gleam:8:21
  │
8 │   replace(in: "🍔🍔🍔" each: "🍔", with: "🍕")
  │                        ^^^^ I was not expecting this
```