### PR TITLE
Added the missing parameter of `special_case_swap_possible` to docs

### DIFF
--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -79,7 +79,7 @@ count_place_treasures(place, treasures)
 
 ## 4. Special Places
 
-Implement the `special_case_swap_possible` function, which takes a treasure (such as `#("Amethyst Octopus", #(1, "F"))`) and a Place (such as `#("Seaside Cottages", #("C", 1))`), and returns `True` for the following combinations:
+Implement the `special_case_swap_possible` function, which takes a treasure (such as `#("Amethyst Octopus", #(1, "F"))`), a Place (such as `#("Seaside Cottages", #("C", 1))`) and a desired treasure (such as `#("Crystal Crab", #(6, "A"))`), and returns `True` for the following combinations:
 
 - The Brass Spyglass can be swapped for any other treasure at the Abandoned Lighthouse.
 - The Amethyst Octopus can be swapped for the Crystal Crab or the Glass Starfish at the Stormy Breakwater.


### PR DESCRIPTION
Hey! I noticed that in the description of the _tisbury-treasure-hunt_ challenge there is an error in section 4 - _Special Places_.

Right now the description states the following: 

> Implement the `special_case_swap_possible` function, which takes a treasure (such as `#("Amethyst Octopus", #(1, "F"))`) and a Place (such as `#("Seaside Cottages", #("C", 1))`), and returns `True` for the following combinations: 
> [...]

So, reading the description I would expect to find the `special_case_swap_possible` function that accepts only two parameters, but instead in the code the function accepts **three** parameters, the additional one being _desired_treasure_.

With that being said, I added the missing parameter to the description of the exercise.
