### PR TITLE
Added "Shinychu" card for testing wrong shiny evaluation

### DIFF
--- a/exercises/concept/gotta-snatch-em-all/test/gotta_snatch_em_all_test.gleam
+++ b/exercises/concept/gotta-snatch-em-all/test/gotta_snatch_em_all_test.gleam
@@ -134,14 +134,16 @@ pub fn total_cards_of_three_collections_test() {
 
 pub fn shiny_cards_with_none_test() {
   gotta_snatch_em_all.shiny_cards(
-    set.from_list(["Blasturtle", "Zumbat", "Hitmonchuck"]),
+    set.from_list(["Blasturtle", "Zumbat", "Hitmonchuck", "Shinychu"]),
   )
   |> should.equal(set.new())
 }
 
 pub fn shiny_cards_with_one_test() {
   gotta_snatch_em_all.shiny_cards(
-    set.from_list(["Blasturtle", "Shiny Phiswan", "Zumbat", "Hitmonchuck"]),
+    set.from_list([
+      "Blasturtle", "Shiny Phiswan", "Zumbat", "Hitmonchuck", "Shinychu",
+    ]),
   )
   |> should.equal(set.from_list(["Shiny Phiswan"]))
 }
@@ -150,7 +152,7 @@ pub fn shiny_cards_with_many_test() {
   gotta_snatch_em_all.shiny_cards(
     set.from_list([
       "Shiny Hitmonchuck", "Blasturtle", "Shiny Shazam", "Shiny Phiswan",
-      "Zumbat", "Hitmonchuck",
+      "Zumbat", "Hitmonchuck", "Shinychu",
     ]),
   )
   |> should.equal(

--- a/exercises/concept/gotta-snatch-em-all/test/gotta_snatch_em_all_test.gleam
+++ b/exercises/concept/gotta-snatch-em-all/test/gotta_snatch_em_all_test.gleam
@@ -134,16 +134,14 @@ pub fn total_cards_of_three_collections_test() {
 
 pub fn shiny_cards_with_none_test() {
   gotta_snatch_em_all.shiny_cards(
-    set.from_list(["Blasturtle", "Zumbat", "Hitmonchuck", "Shinychu"]),
+    set.from_list(["Blasturtle", "Zumbat", "Hitmonchuck"]),
   )
   |> should.equal(set.new())
 }
 
 pub fn shiny_cards_with_one_test() {
   gotta_snatch_em_all.shiny_cards(
-    set.from_list([
-      "Blasturtle", "Shiny Phiswan", "Zumbat", "Hitmonchuck", "Shinychu",
-    ]),
+    set.from_list(["Blasturtle", "Shiny Phiswan", "Zumbat", "Hitmonchuck"]),
   )
   |> should.equal(set.from_list(["Shiny Phiswan"]))
 }
@@ -152,10 +150,17 @@ pub fn shiny_cards_with_many_test() {
   gotta_snatch_em_all.shiny_cards(
     set.from_list([
       "Shiny Hitmonchuck", "Blasturtle", "Shiny Shazam", "Shiny Phiswan",
-      "Zumbat", "Hitmonchuck", "Shinychu",
+      "Zumbat", "Hitmonchuck",
     ]),
   )
   |> should.equal(
     set.from_list(["Shiny Hitmonchuck", "Shiny Phiswan", "Shiny Shazam"]),
   )
+}
+
+pub fn fake_shiny_not_included_test() {
+  gotta_snatch_em_all.shiny_cards(
+    set.from_list(["Shiny Hitmonchuck", "Shinychu"]),
+  )
+  |> should.equal(set.from_list(["Shiny Hitmonchuck"]))
 }


### PR DESCRIPTION
[no important files changed]

Hey!

This pull request adds a (useless) not covered case in [Gotta Snatch 'Em All` exercise](https://exercism.org/tracks/gleam/exercises/gotta-snatch-em-all), which is the "fake shiny" card (feel free to name the case the way you like). 

Basically the instructions of the last part of the exercise states:
> Implement shiny_cards, which takes a collection and returns a set containing all the cards that start with "Shiny ".

That means that cards starting with "Shiny" **without a space** should not be considered shiny cards. For example, the totally made up card _Shinychu_ should not be considered as shiny. However in the current state of the exercise I could write a function that filters for strings starting with "Shiny" and the tests pass.

To correct this behavior, I added the _Shinychu_ card to all the tests regarding shiny cards. For example:

```gleam
pub fn shiny_cards_with_none_test() {
  gotta_snatch_em_all.shiny_cards(
    set.from_list(["Blasturtle", "Zumbat", "Hitmonchuck", "Shinychu"]),  // <-- here the added fake shiny card
  )
  |> should.equal(set.new())
}
```

This is probably a useless correction, but I think it better completes the exercise.

PS: this is a retake of a previous pull request, but with the _[no important files changed]_ string added to the commit body since there is no need at all to re-test all students' submissions.