### PR TITLE
Fix code example and add missing link

### DIFF
--- a/exercises/concept/gotta-snatch-em-all/.docs/hints.md
+++ b/exercises/concept/gotta-snatch-em-all/.docs/hints.md
@@ -53,4 +53,5 @@
 [filter]: https://hexdocs.pm/gleam_stdlib/gleam/set.html#filter
 [new]: https://hexdocs.pm/gleam_stdlib/gleam/set.html#new
 [union]: https://hexdocs.pm/gleam_stdlib/gleam/set.html#union
+[size]: https://hexdocs.pm/gleam_stdlib/gleam/set.html#size
 [intersection]: https://hexdocs.pm/gleam_stdlib/gleam/set.html#intersection

--- a/exercises/concept/gotta-snatch-em-all/.docs/instructions.md
+++ b/exercises/concept/gotta-snatch-em-all/.docs/instructions.md
@@ -22,7 +22,7 @@ Once you have a collection, it takes a life of its own and must grow.
 Implement `add_card`, which takes a card and a collection, and returns a tuple with two values: a `Bool` that indicates if the card was already in the collection, and the collection with the card added.
 
 ```gleam
-add_card("Scientuna" set.from_list(["Newthree"]))
+add_card(set.from_list(["Newthree"]), "Scientuna")
 // -> #(False, set.from_list(["Newthree", "Scientuna"]))
 ```
 


### PR DESCRIPTION
The code example for the `add_card` function instructions uses invalid syntax.
This change fixes it to use the correct parameters.

In addition, there is a broken link in one of the hints.