### PR TITLE
docs(erlang-extraction): Add hints that point toward docs

### DIFF
--- a/exercises/concept/erlang-extraction/.docs/hints.md
+++ b/exercises/concept/erlang-extraction/.docs/hints.md
@@ -11,11 +11,13 @@
 
 ## 3. Define the `insert` function
 
+- Check the `gb_trees:insert/3` documentation to confirm the correct order of arguments.
 - The external function can be a private function that is called by the `insert` function in order to change the order of the arguments.
 - The function should use the `gb_trees:insert/3`.
 
 ## 4. Define the `delete` function
 
+- Check the `gb_trees:delete_any/2` documentation to confirm the correct order of arguments.
 - The external function can be a private function that is called by the `delete` function in order to change the order of the arguments.
 - The function should use the `gb_trees:delete_any/2`.
 - The `gb_trees:delete/2` function will crash if the key is not found, so it should not be used.


### PR DESCRIPTION
I felt that the hints on 'Erlang Extraction' weren't direct enough in hinting that the external functions had a different order than the predefined functions used for testing. Despite the current hints that allude to a different order I still didn't quite get the picture so I wanted to add something that was a little more direct. 