### PR TITLE
fix pacman_rules by adding an extra test if all the dots are not eaten

### DIFF
--- a/exercises/concept/pacman-rules/test/pacman_rules_test.gleam
+++ b/exercises/concept/pacman-rules/test/pacman_rules_test.gleam
@@ -56,3 +56,7 @@ pub fn dont_win_if_all_dots_eaten_but_touching_ghost_test() {
 pub fn win_if_all_dots_eaten_and_touching_ghost_with_power_pellet_active_test() {
   let assert True = pacman_rules.win(True, True, True)
 }
+
+pub fn dont_win_if_not_all_dots_eaten_test() {
+  let assert False = pacman_rules.win(False, False, False)
+}


### PR DESCRIPTION
There is currently no test case for when all the dots are not eaten.
This allows for solutions that do not use the `has_eaten_all_dots` argument.

Here is an [example](https://exercism.org/tracks/gleam/exercises/pacman-rules/solutions/drinklilt)