### PR TITLE
Updated gotta-snatch-em-all intro docs

### DIFF
--- a/exercises/concept/gotta-snatch-em-all/.docs/introduction.md
+++ b/exercises/concept/gotta-snatch-em-all/.docs/introduction.md
@@ -30,9 +30,6 @@ set.insert(eighty_eight, 88)
 set.insert(eighty_eight, 89)
 // -> set.from_list([88, 89])
 
-set.delete(eighty_eight, 88)
-// -> set.from_list([])
-
 set.delete(eighty_eight, 89)
 // -> set.from_list([88])
 ```


### PR DESCRIPTION
This update removes an example set.delete() with an incorrect return value.

I thought it would be better to remove the example instead of fixing the return value since the `set.contains` and `set.size` examples are expecting `set.from_list([88])`.