### PR TITLE
(lasagna) Remove ambiguity in example for `total_time_in_minutes`

### DIFF
--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -36,8 +36,8 @@ preparation_time_in_minutes(2)
 Define the `total_time_in_minutes` function that takes two arguments: the first argument is the number of layers you added to the lasagna, and the second argument is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 
 ```gleam
-total_time_in_minutes(3, 20)
-// -> 26
+total_time_in_minutes(3, 10)
+// -> 16
 ```
 
 ## 5. Create a notification that the lasagna is ready


### PR DESCRIPTION
According to the example before,
```gleam
pub fn total_time_in_minutes(layers: Int, elapsed: Int) {preparation_time_in_minutes(layers) + remaining_minutes_in_oven(elapsed)}
```
and
```gleam
pub fn total_time_in_minutes(layers: Int, elapsed: Int) {preparation_time_in_minutes(layers) + elapsed}
```
would both be valid, but only the latter is correct.