### PR TITLE
fix gleam configuration files

### DIFF
--- a/bin/sync-exercise-project-configs
+++ b/bin/sync-exercise-project-configs
@@ -31,7 +31,7 @@ check() {
   project="$1"
   update_config_name "$project"
 
-  if ! diff "$canonical_config" "$project"/gleam.toml || 
+  if ! diff "$canonical_config" "$project"/gleam.toml ||
     ! diff "$canonical_manifest" "$project"/manifest.toml
   then
     echo "ERROR: Config files are out of sync with gleam-test-runner config" 1>&2
@@ -47,7 +47,7 @@ sync() {
   cp "$canonical_manifest" "$project"/manifest.toml
 }
 
-packages_prefix="https://raw.githubusercontent.com/exercism/gleam-test-runner/main/packages"
+packages_prefix="https://raw.githubusercontent.com/exercism/gleam-test-runner/refs/tags/v1.8.0/packages"
 project_dir="$(dirname "$(dirname "$0")")"
 tmp_dir="$(mktemp -d)"
 canonical_config="$tmp_dir"/gleam.toml

--- a/bin/test
+++ b/bin/test
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # Synopsis:
 # Test the track's exercises.
-# 
-# At a minimum, this file must check if the example/exemplar solution of each 
+#
+# At a minimum, this file must check if the example/exemplar solution of each
 # Practice/Concept Exercise passes the exercise's tests.
 #
 # To check this, you usually have to (temporarily) replace the exercise's solution files
@@ -85,7 +85,7 @@ pub fn main() {
 }
 EOT
 
-  packages_prefix="https://raw.githubusercontent.com/exercism/gleam-test-runner/main/packages"
+  packages_prefix="https://raw.githubusercontent.com/exercism/gleam-test-runner/refs/tags/v1.8.0/packages"
   download all_exercises/gleam.toml "$packages_prefix"/gleam.toml
   download all_exercises/manifest.toml "$packages_prefix"/manifest.toml
   sed -i -e "s/name = \".*\"/name = \"all_exercises\"/" all_exercises/gleam.toml


### PR DESCRIPTION
Fix gleam configuration files based on git tags instead of main branch.

Related to the release of #542 and https://github.com/exercism/gleam-test-runner/pull/83.

When one updates the gleam test runner it can cause the exercise solutions to not compile anymore. With this, the process would be independent. The downside is that one would also need to update the scripts when releasing an new rest runner version.
