### PR TITLE
UPDATE: Change to correct float comparisons

### DIFF
--- a/exercises/concept/bandwagoner/.docs/introduction.md
+++ b/exercises/concept/bandwagoner/.docs/introduction.md
@@ -58,7 +58,7 @@ Labels can also be used when pattern matching to extract values from records.
 ```gleam
 pub fn is_tall(rect: Rectangle) {
   case rect {
-    Rectangle(height: h, width: _) if h > 20.0 -> True
+    Rectangle(height: h, width: _) if h >. 20.0 -> True
     _ -> False
   }
 }
@@ -69,7 +69,7 @@ If we only want to match on some of the fields we can use the spread operator `.
 ```gleam
 pub fn is_tall(rect: Rectangle) {
   case rect {
-    Rectangle(height: h, ..) if h > 20.0 -> True
+    Rectangle(height: h, ..) if h >. 20.0 -> True
     _ -> False
   }
 }


### PR DESCRIPTION
I noticed that we were using using the wrong expression for comparisons on Float types on Gleam, replace `>` to `>.`