### PR TITLE
fix(tests): add isolated test for Chicago Bulls team condition

### DIFF
--- a/exercises/concept/bandwagoner/test/bandwagoner_test.gleam
+++ b/exercises/concept/bandwagoner/test/bandwagoner_test.gleam
@@ -220,6 +220,14 @@ pub fn root_for_team_with_more_losses_than_wins_and_non_former_player_coach_test
   let assert True = bandwagoner.root_for_team(team)
 }
 
+pub fn root_for_team_chicago_bulls_test() {
+  let stats = bandwagoner.create_stats(50, 13)
+  let coach = bandwagoner.create_coach("Billy Donovan", False)
+  let team = bandwagoner.create_team("Chicago Bulls", coach, stats)
+
+  let assert True = bandwagoner.root_for_team(team)
+}
+
 pub fn dont_root_for_team_not_matching_criteria_test() {
   let stats = bandwagoner.create_stats(51, 31)
   let coach = bandwagoner.create_coach("Frank Layden", False)


### PR DESCRIPTION
This PR adds a **test case** that **specifically** validates the **"Chicago Bulls" condition**
in `root_for_team()` without relying on other passing conditions like `former_player` status or win/loss ratios.

**How to reproduce the issue ?** Simply remove the `team.name == "Chicago Bulls"`in this currently passing Exercism solution and it will have no effect (= they still pass, and all other conditions are explicitely tested **except this one**) :

```
pub fn root_for_team(team: Team) -> Bool {
  team.coach.name == "Gregg Popovich" || team.coach.former_player
  || team.name == "Chicago Bulls" || team.stats.wins >= 60
  || team.stats.losses > team.stats.wins
}
```