### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 For this exercise, please refrain from using the `gleam/set` module.

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 For this exercise, please refrain from using the `gleam/set` module.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.