### PR TITLE
Update pacman_rules_test.gleam

### DIFF
--- a/exercises/concept/pacman-rules/test/pacman_rules_test.gleam
+++ b/exercises/concept/pacman-rules/test/pacman_rules_test.gleam
@@ -49,10 +49,14 @@ pub fn win_if_all_dots_eaten_test() {
   let assert True = pacman_rules.win(True, False, False)
 }
 
-pub fn dont_win_if_all_dots_eaten_but_touching_ghost_test() {
-  let assert False = pacman_rules.win(True, False, True)
+pub fn win_if_all_dots_eaten_and_touching_ghost_with_power_pellet_active_test() {
+  let assert True = pacman_rules.win(True, True, True)
 }
 
 pub fn win_if_all_dots_eaten_and_touching_ghost_with_power_pellet_active_test() {
-  let assert True = pacman_rules.win(True, True, True)
+  let assert True = pacman_rules.win(True, True, False)
+}
+
+pub fn dont_win_if_all_dots_eaten_but_touching_ghost_test() {
+  let assert False = pacman_rules.win(True, False, True)
 }


### PR DESCRIPTION
There are 3 instances that become True for the function win. However, only 2 are tested, and I have seen proposed solutions where this last instance is left out and taken as solved.

The missing instance is the following:
let assert True = pacman_rules.win(True, True, False)